### PR TITLE
bisection: Add an initial script for future bisection exercises.

### DIFF
--- a/bisection/README.md
+++ b/bisection/README.md
@@ -1,0 +1,10 @@
+# What's in this directory?
+The directory contains one Python script, used to simulate a real-world application in your repo. Now we suppose this script is the most important application in this repo and we need to make sure it run all the time. The purpose is for the users to learn to use bisection tools to find out when the script stops to work.
+
+# What is the application doing?
+It counts the number of lines of comments in the whole repo, by only considering supported program types: java, js and html. When the number of lines exceeds the limit (by default it's 1000, but user can override it with an argument. See `./bisection/application.py --help` for how-to.
+
+# What do you need to do?
+Execute the binary with `./bisection/application.py` occasionally (don't do it after every commit, as you might know the answer), to see if it prints the number of comments in the repo without any errors. If not, you can relax: The "Application" is working!
+
+When you see `RuntimeError: Oh no!!!! You have xx lines of comments, exceeding the threshold of xx`, it means the application stops to work. This is the time you need to start to read documents on how to use `git bisection` to find out the culprit commit. https://git-scm.com/docs/git-bisect is a good start.

--- a/bisection/application.py
+++ b/bisection/application.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python2
+
+"""The fake-core binary of your application
+
+Assume this is the core binary of your application. Assume your goal
+is to keep this binary running without any problems. The purpose is
+to train you using `git bisection` to find out which commit causes
+this binary stopped to work.
+
+The algorithm of this script is to find out how many lines of
+comments are there in the repo. If it exceeds the number we pass
+to this program, it'll raise an exception.
+"""
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+COMMENT_STYLES = {
+    '.java': ['//', ('/*', '*/')],
+    '.js': ['//'],
+    '.html': [('<!--', '-->')],
+}
+
+def count_comments_from_contents(contents, style):
+    lines = 0
+    if isinstance(style, str):
+        # Consider single line comments
+        for line in contents.split('\n'):
+            if line.strip().startswith(style):
+                lines += 1
+        return lines
+
+    if isinstance(style, tuple):
+        # Consider multi-line comments
+        begin, end = style
+        in_comment_section = False
+        for line in contents.split('\n'):
+            if line.strip().startswith(begin):
+                lines += 1
+                in_comment_section = True
+            elif line.strip().startswith(end):
+                lines += 1
+                in_comment_section = False
+            elif in_comment_section:
+                lines += 1
+        return lines
+
+def count_comments(path):
+    for ext, styles in COMMENT_STYLES.items():
+        if path.endswith(ext):
+            comment_lines = 0
+            with open(path) as f:
+                contents = f.read()
+            for s in styles:
+                comment_lines += count_comments_from_contents(contents, s)
+
+            if comment_lines:
+                print('Found %d lines of comments in %s' % (comment_lines, path))
+            return comment_lines
+    assert '%s not ending with any supported file extensions' % path
+
+def collect_programs(threshold_lines):
+    directory = os.path.abspath(os.path.dirname(__file__))
+    total_lines = 0
+    for top in [os.path.join(directory, '../frontend'),
+              os.path.join(directory, '../backend')]:
+        for root, _, files in os.walk(top):
+            for f in files:
+                if f.endswith(tuple(COMMENT_STYLES.keys())):
+                    total_lines += count_comments(os.path.join(root, f))
+    if total_lines > threshold_lines:
+        raise RuntimeError('Oh no!!!! You have %d lines of comments, exceeding the threshold of %d' % (total_lines, threshold_lines))
+    print('You have total of %d lines of comments in all %s files in the repo' % (
+        total_lines, COMMENT_STYLES.keys()))
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--number',
+        type=int,
+        default=1000,
+        help='The "ideal" number of comments in all of these repo. Exceeding this number will cause this script to raise an error. Default is %(default)s'
+    )
+
+    options = parser.parse_args(argv)
+    collect_programs(options.number)
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))

--- a/bisection/application.py
+++ b/bisection/application.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python2
-
 """The fake-core binary of your application
 
 Assume this is the core binary of your application. Assume your goal
@@ -20,9 +19,11 @@ import sys
 
 COMMENT_STYLES = {
     '.java': ['//', ('/*', '*/')],
-    '.js': ['//'],
+    '.js': ['//', ('/*', '*/')],
     '.html': [('<!--', '-->')],
+    '.xml': [('<!--', '-->')],
 }
+
 
 def count_comments_from_contents(contents, style):
     lines = 0
@@ -48,6 +49,7 @@ def count_comments_from_contents(contents, style):
                 lines += 1
         return lines
 
+
 def count_comments(path):
     for ext, styles in COMMENT_STYLES.items():
         if path.endswith(ext):
@@ -58,23 +60,31 @@ def count_comments(path):
                 comment_lines += count_comments_from_contents(contents, s)
 
             if comment_lines:
-                print('Found %d lines of comments in %s' % (comment_lines, path))
+                print('Found %d lines of comments in %s' %
+                      (comment_lines, path))
             return comment_lines
     assert '%s not ending with any supported file extensions' % path
+
 
 def collect_programs(threshold_lines):
     directory = os.path.abspath(os.path.dirname(__file__))
     total_lines = 0
-    for top in [os.path.join(directory, '../frontend'),
-              os.path.join(directory, '../backend')]:
+    for top in [
+            os.path.join(directory, '../frontend'),
+            os.path.join(directory, '../backend')
+    ]:
         for root, _, files in os.walk(top):
             for f in files:
                 if f.endswith(tuple(COMMENT_STYLES.keys())):
                     total_lines += count_comments(os.path.join(root, f))
     if total_lines > threshold_lines:
-        raise RuntimeError('Oh no!!!! You have %d lines of comments, exceeding the threshold of %d' % (total_lines, threshold_lines))
-    print('You have total of %d lines of comments in all %s files in the repo' % (
-        total_lines, COMMENT_STYLES.keys()))
+        raise RuntimeError(
+            'Oh no!!!! You have %d lines of comments, exceeding the threshold of %d'
+            % (total_lines, threshold_lines))
+    print(
+        'You have total of %d lines of comments in all %s files in the repo' %
+        (total_lines, COMMENT_STYLES.keys()))
+
 
 def main(argv):
     parser = argparse.ArgumentParser()
@@ -82,11 +92,14 @@ def main(argv):
         '--number',
         type=int,
         default=1000,
-        help='The "ideal" number of comments in all of these repo. Exceeding this number will cause this script to raise an error. Default is %(default)s'
-    )
+        help=(
+            'The "ideal" number of comments in all of these repo. '
+            'Exceeding this number will cause this script to raise an error. '
+            'Default is %(default)s'))
 
     options = parser.parse_args(argv)
     collect_programs(options.number)
 
+
 if __name__ == '__main__':
-  sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
The idea of the script is to count how many lines of comments are
there in the repo. So over time, when the repo grows, one comment
will make it over the set limit, to trigger the alert. This is
when you can start to use `git bisect` to find out the culprit.
In this way, you won't actually know which commit triggers the
exception by just looking at the commit contents (hopefully!)

Also, just in case you want to start earlier, or the number of
commits never go above the default value (1000), the script also
takes an argument to change the limit, so we can start the
exercise anytime.

As long as python is installed on your machine, the script should
be able to execute. Will seek other options if that's not working

Added a README as instructions.