### PR TITLE
bisection: Ignore directories that don't have any source code

### DIFF
--- a/bisection/application.py
+++ b/bisection/application.py
@@ -24,6 +24,7 @@ COMMENT_STYLES = {
     '.xml': [('<!--', '-->')],
 }
 
+IGNORE_DIRECTORIES = ['node_modules', 'build']
 
 def count_comments_from_contents(contents, style):
     lines = 0
@@ -74,6 +75,9 @@ def collect_programs(threshold_lines):
             os.path.join(directory, '../backend')
     ]:
         for root, _, files in os.walk(top):
+            # Ignore all ignored directories
+            if [x for x in IGNORE_DIRECTORIES if x in root]:
+                continue
             for f in files:
                 if f.endswith(tuple(COMMENT_STYLES.keys())):
                     total_lines += count_comments(os.path.join(root, f))


### PR DESCRIPTION
Add a list of directories that the program needs to ignore, mainly
node_modules, as it might appear on user's local directory but
actually doesn't contain any source code