### PR TITLE
Add User and UserDatastore classes

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -61,6 +61,34 @@
       <artifactId>guava</artifactId>
       <version>29.0-jre</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/main/java/com/google/sps/data/User.java
+++ b/backend/src/main/java/com/google/sps/data/User.java
@@ -1,0 +1,28 @@
+package com.google.sps.data;
+
+
+/** A user with saved preferences. */
+public final class User {
+
+  /** Datastore ID */
+  private final long id;
+  /** Google username (ldap) */
+  private final String username;
+  /** Time of submitted form */
+  private final long timestamp;
+
+  /** Initialize constructor fields */
+  public Participant(long id, String username, long timestamp) {
+    this.id = id;
+    this.username = username;
+    this.timestamp = timestamp;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+}

--- a/backend/src/main/java/com/google/sps/data/User.java
+++ b/backend/src/main/java/com/google/sps/data/User.java
@@ -22,4 +22,8 @@ public final class User {
   public String getUsername() {
     return username;
   }
+
+  public String toString() {
+    return "username=" + username + "\n";
+  }
 }

--- a/backend/src/main/java/com/google/sps/data/User.java
+++ b/backend/src/main/java/com/google/sps/data/User.java
@@ -1,5 +1,7 @@
 package com.google.sps.data;
 
+import com.google.common.base.MoreObjects;
+
 /** A user with saved preferences. */
 public final class User {
 
@@ -24,6 +26,6 @@ public final class User {
   }
 
   public String toString() {
-    return "username=" + username + "\n";
+    return MoreObjects.toStringHelper(this).add("id", id).add("username", username).toString();
   }
 }

--- a/backend/src/main/java/com/google/sps/data/User.java
+++ b/backend/src/main/java/com/google/sps/data/User.java
@@ -1,6 +1,5 @@
 package com.google.sps.data;
 
-
 /** A user with saved preferences. */
 public final class User {
 
@@ -8,14 +7,12 @@ public final class User {
   private final long id;
   /** Google username (ldap) */
   private final String username;
-  /** Time of submitted form */
-  private final long timestamp;
 
   /** Initialize constructor fields */
-  public Participant(long id, String username, long timestamp) {
+  public User(long id, String username) {
+    // TODO(#32): add User interests
     this.id = id;
     this.username = username;
-    this.timestamp = timestamp;
   }
 
   public long getId() {

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -46,12 +46,6 @@ public final class UserDatastore {
     }
   }
 
-  /** Return User from username, or null if user with username not in datastore */
-  @Nullable
-  public User getUserFromUsername(String username) {
-    return getUserFromEntity(getEntityFromUsername(username));
-  }
-
   /** Return user object from datastore user entity, or null if entity is null */
   @Nullable
   private static User getUserFromEntity(Entity entity) {
@@ -67,6 +61,11 @@ public final class UserDatastore {
     return new User(id, username);
   }
 
+  /** Return User from username, or null if user with username not in datastore */
+  public User getUserFromUsername(String username) {
+    return getUserFromEntity(getEntityFromUsername(username));
+  }
+
   /** Return String representation of users for logging purposes */
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -74,7 +73,7 @@ public final class UserDatastore {
     PreparedQuery results = datastore.prepare(query);
     for (Entity entity : results.asIterable()) {
       User user = getUserFromEntity(entity);
-      sb.append("username=" + user.getUsername());
+      sb.append("username=" + user.getUsername() + "\n");
     }
     return sb.toString();
   }

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -1,0 +1,48 @@
+package com.google.sps.datastore;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.Entity;
+import com.google.sps.data.User;
+
+/** Separates datastore method calls involving User type from caller */
+public final class UserDatastore {
+
+  // Datastore Key/Property constants
+  private static final String KIND_USER = "User";
+  private static final String PROPERTY_USERNAME = "username";
+  private static final String PROPERTY_TIMESTAMP = "timestamp";
+
+  /** Formatter for converting between String and ZonedDateTime */
+  private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME;
+
+  /** Datastore */
+  private final DatastoreService datastore;
+
+  /** Constructor that takes in DatastoreService */
+  public UserDatastore(DatastoreService datastore) {
+    this.datastore = datastore;
+  }
+
+  /** Put user in datastore. Overwrite user entity if user with same username already exists. */
+  public void addUser(User user) {
+    // Set properties of entity based on user fields
+    Entity userEntity = new Entity(KIND_USER, user.getUsername());
+    userEntity.setProperty(PROPERTY_USERNAME, user.getUsername());
+    userEntity.setProperty(PROPERTY_TIMESTAMP, user.getTimestamp());
+
+    // Insert entity into datastore
+    datastore.put(userEntity);
+  }
+
+  /** Return String representation of participants for logging purposes */
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    Query query = new Query(KIND_USER);
+    PreparedQuery results = datastore.prepare(query);
+    for (Entity entity : results.asIterable()) {
+      User user = getParticipantFromEntity(entity);
+      sb.append("username=" + user.getUsername());
+    }
+    return sb.toString();
+  }
+}

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -60,6 +60,7 @@ public final class UserDatastore {
     }
 
     // Get entity properties
+    long id = (long) entity.getKey().getId();
     String username = (String) entity.getProperty(PROPERTY_USERNAME);
 
     // Create and return new User

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -10,10 +10,6 @@ public final class UserDatastore {
   // Datastore Key/Property constants
   private static final String KIND_USER = "User";
   private static final String PROPERTY_USERNAME = "username";
-  private static final String PROPERTY_TIMESTAMP = "timestamp";
-
-  /** Formatter for converting between String and ZonedDateTime */
-  private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
   /** Datastore */
   private final DatastoreService datastore;
@@ -28,19 +24,49 @@ public final class UserDatastore {
     // Set properties of entity based on user fields
     Entity userEntity = new Entity(KIND_USER, user.getUsername());
     userEntity.setProperty(PROPERTY_USERNAME, user.getUsername());
-    userEntity.setProperty(PROPERTY_TIMESTAMP, user.getTimestamp());
 
     // Insert entity into datastore
     datastore.put(userEntity);
   }
 
-  /** Return String representation of participants for logging purposes */
+  /** Return User Entity from username, or null if entity is not found */
+  @Nullable
+  private Entity getEntityFromUsername(String username) {
+    Key userKey = KeyFactory.createKey(KIND_USER, username);
+    try {
+      return datastore.get(userKey);
+    } catch (EntityNotFoundException e) {
+      return null;
+    }
+  }
+
+  /** Return User from username, or null if user with username not in datastore */
+  @Nullable
+  public User getUserFromUsername(String username) {
+    return getUserFromEntity(getEntityFromUsername(username));
+  }
+
+  /** Return user object from datastore user entity, or null if entity is null */
+  @Nullable
+  private static User getUserFromEntity(Entity entity) {
+    if (entity == null) {
+      return null;
+    }
+
+    // Get entity properties
+    String username = (String) entity.getProperty(PROPERTY_USERNAME);
+
+    // Create and return new User
+    return new User(id, username);
+  }
+
+  /** Return String representation of users for logging purposes */
   public String toString() {
     StringBuilder sb = new StringBuilder();
     Query query = new Query(KIND_USER);
     PreparedQuery results = datastore.prepare(query);
     for (Entity entity : results.asIterable()) {
-      User user = getParticipantFromEntity(entity);
+      User user = getUserFromEntity(entity);
       sb.append("username=" + user.getUsername());
     }
     return sb.toString();

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -2,6 +2,11 @@ package com.google.sps.datastore;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
 import com.google.sps.data.User;
 import javax.annotation.Nullable;
 

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -5,8 +5,6 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
 import com.google.sps.data.User;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -59,23 +57,12 @@ public final class UserDatastore {
   }
 
   /** Return User from username, or null if user with username not in datastore */
+  @Nullable
   public User getUserFromUsername(String username) {
     Entity entity = getEntity(username);
     if (entity == null) {
       return null;
     }
     return getUserFromEntity(entity);
-  }
-
-  /** Return String representation of users for logging purposes */
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    Query query = new Query(KIND_USER);
-    PreparedQuery results = datastore.prepare(query);
-    for (Entity entity : results.asIterable()) {
-      User user = getUserFromEntity(entity);
-      sb.append(user.toString());
-    }
-    return sb.toString();
   }
 }

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -3,6 +3,7 @@ package com.google.sps.datastore;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.Entity;
 import com.google.sps.data.User;
+import javax.annotation.Nullable;
 
 /** Separates datastore method calls involving User type from caller */
 public final class UserDatastore {

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -71,7 +71,7 @@ public final class UserDatastore {
     PreparedQuery results = datastore.prepare(query);
     for (Entity entity : results.asIterable()) {
       User user = getUserFromEntity(entity);
-      sb.append("username=" + user.getUsername() + "\n");
+      sb.append(user.toString());
     }
     return sb.toString();
   }

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -50,9 +50,6 @@ public final class UserDatastore {
   /** Return user object from datastore user entity, or null if entity is null */
   @Nullable
   private static User getUserFromEntity(@Nonnull Entity entity) {
-    if (entity == null) {
-      return null;
-    }
 
     // Get entity properties
     long id = (long) entity.getKey().getId();

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -8,6 +8,7 @@ import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.sps.data.User;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Separates datastore method calls involving User type from caller */
@@ -37,7 +38,7 @@ public final class UserDatastore {
 
   /** Return User Entity from username, or null if entity is not found */
   @Nullable
-  private Entity getEntityFromUsername(String username) {
+  private Entity getEntity(String username) {
     Key userKey = KeyFactory.createKey(KIND_USER, username);
     try {
       return datastore.get(userKey);
@@ -48,7 +49,7 @@ public final class UserDatastore {
 
   /** Return user object from datastore user entity, or null if entity is null */
   @Nullable
-  private static User getUserFromEntity(Entity entity) {
+  private static User getUserFromEntity(@Nonnull Entity entity) {
     if (entity == null) {
       return null;
     }
@@ -63,7 +64,7 @@ public final class UserDatastore {
 
   /** Return User from username, or null if user with username not in datastore */
   public User getUserFromUsername(String username) {
-    return getUserFromEntity(getEntityFromUsername(username));
+    return getUserFromEntity(getEntity(username));
   }
 
   /** Return String representation of users for logging purposes */

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -50,7 +50,6 @@ public final class UserDatastore {
   /** Return user object from datastore user entity, or null if entity is null */
   @Nullable
   private static User getUserFromEntity(@Nonnull Entity entity) {
-
     // Get entity properties
     long id = (long) entity.getKey().getId();
     String username = (String) entity.getProperty(PROPERTY_USERNAME);
@@ -61,7 +60,11 @@ public final class UserDatastore {
 
   /** Return User from username, or null if user with username not in datastore */
   public User getUserFromUsername(String username) {
-    return getUserFromEntity(getEntity(username));
+    Entity entity = getEntity(username);
+    if (entity == null) {
+      return null;
+    }
+    return getUserFromEntity(entity);
   }
 
   /** Return String representation of users for logging purposes */

--- a/backend/src/test/java/com/google/sps/UserDatastoreTest.java
+++ b/backend/src/test/java/com/google/sps/UserDatastoreTest.java
@@ -1,0 +1,112 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.sps.data.User;
+import com.google.sps.datastore.UserDatastore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class UserDatastoreTest {
+
+  // Default values
+  private static final long ID_DEFAULT = 0;
+
+  // Some usernames
+  private static final String PERSON_A = "Person A";
+  private static final String PERSON_B = "Person B";
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void addOneUser() {
+    // Add one user to datastore
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    UserDatastore userDatastore = new UserDatastore(datastore);
+
+    User userA = new User(ID_DEFAULT, PERSON_A);
+
+    userDatastore.addUser(userA);
+
+    String expected = "username=" + PERSON_A + "\n";
+    assertThat(userDatastore.toString()).isEqualTo(expected);
+  }
+
+  @Test
+  public void addTwoUsers() {
+    // Add two users to datastore
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    UserDatastore userDatastore = new UserDatastore(datastore);
+
+    User userA = new User(ID_DEFAULT, PERSON_A);
+    User userB = new User(ID_DEFAULT, PERSON_B);
+
+    userDatastore.addUser(userA);
+    userDatastore.addUser(userB);
+
+    String expected = "username=" + PERSON_A + "\nusername=" + PERSON_B + "\n";
+    assertThat(userDatastore.toString()).isEqualTo(expected);
+  }
+
+  @Test
+  public void addGetTwoUsers() {
+    // Add two users to datastore, return user from username
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    UserDatastore userDatastore = new UserDatastore(datastore);
+
+    User userA = new User(ID_DEFAULT, PERSON_A);
+    User userB = new User(ID_DEFAULT, PERSON_B);
+
+    userDatastore.addUser(userA);
+    userDatastore.addUser(userB);
+
+    assertThat(userDatastore.getUserFromUsername(PERSON_A).getUsername()).isEqualTo(PERSON_A);
+    assertThat(userDatastore.getUserFromUsername(PERSON_B).getUsername()).isEqualTo(PERSON_B);
+  }
+
+  @Test
+  public void getNonexistentUser() {
+    // Try to get user from username that's not in datastore
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    UserDatastore userDatastore = new UserDatastore(datastore);
+
+    assertThat(userDatastore.getUserFromUsername(PERSON_A)).isEqualTo(null);
+  }
+}

--- a/backend/src/test/java/com/google/sps/UserDatastoreTest.java
+++ b/backend/src/test/java/com/google/sps/UserDatastoreTest.java
@@ -49,6 +49,7 @@ public final class UserDatastoreTest {
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
 
+  // TODO(#37): Find/write JUnit rule to encapsulate setUp() and tearDown()
   @Before
   public void setUp() {
     helper.setUp();

--- a/backend/src/test/java/com/google/sps/UserDatastoreTest.java
+++ b/backend/src/test/java/com/google/sps/UserDatastoreTest.java
@@ -107,7 +107,7 @@ public final class UserDatastoreTest {
     assertThat(userDatastore.getUserFromUsername(PERSON_B).getUsername()).isEqualTo(PERSON_B);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void getNonexistentUser() {
     // Try to get user from username that's not in datastore
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/backend/src/test/java/com/google/sps/UserDatastoreTest.java
+++ b/backend/src/test/java/com/google/sps/UserDatastoreTest.java
@@ -65,6 +65,7 @@ public final class UserDatastoreTest {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
     User userA = new User(ID_DEFAULT, PERSON_A);
+
     userDatastore.addUser(userA);
 
     Key keyA = KeyFactory.createKey(KIND_USER, PERSON_A);
@@ -82,6 +83,7 @@ public final class UserDatastoreTest {
 
     userDatastore.addUser(userA);
     userDatastore.addUser(userB);
+
     Key keyA = KeyFactory.createKey(KIND_USER, PERSON_A);
     Key keyB = KeyFactory.createKey(KIND_USER, PERSON_B);
     Entity entityA = datastore.get(keyA);
@@ -97,6 +99,7 @@ public final class UserDatastoreTest {
     UserDatastore userDatastore = new UserDatastore(datastore);
     User userA = new User(ID_DEFAULT, PERSON_A);
     User userB = new User(ID_DEFAULT, PERSON_B);
+
     userDatastore.addUser(userA);
     userDatastore.addUser(userB);
 

--- a/backend/src/test/java/com/google/sps/UserDatastoreTest.java
+++ b/backend/src/test/java/com/google/sps/UserDatastoreTest.java
@@ -54,12 +54,9 @@ public final class UserDatastoreTest {
   @Test
   public void addOneUser() {
     // Add one user to datastore
-
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
-
     User userA = new User(ID_DEFAULT, PERSON_A);
-
     userDatastore.addUser(userA);
 
     String expected = "username=" + PERSON_A + "\n";
@@ -69,13 +66,10 @@ public final class UserDatastoreTest {
   @Test
   public void addTwoUsers() {
     // Add two users to datastore
-
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
-
     User userA = new User(ID_DEFAULT, PERSON_A);
     User userB = new User(ID_DEFAULT, PERSON_B);
-
     userDatastore.addUser(userA);
     userDatastore.addUser(userB);
 
@@ -86,13 +80,10 @@ public final class UserDatastoreTest {
   @Test
   public void addGetTwoUsers() {
     // Add two users to datastore, return user from username
-
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
-
     User userA = new User(ID_DEFAULT, PERSON_A);
     User userB = new User(ID_DEFAULT, PERSON_B);
-
     userDatastore.addUser(userA);
     userDatastore.addUser(userB);
 
@@ -103,10 +94,9 @@ public final class UserDatastoreTest {
   @Test
   public void getNonexistentUser() {
     // Try to get user from username that's not in datastore
-
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
 
-    assertThat(userDatastore.getUserFromUsername(PERSON_A)).isEqualTo(null);
+    assertThat(userDatastore.getUserFromUsername(PERSON_A)).isNull();
   }
 }


### PR DESCRIPTION
This PR introduces the User and UserDatastore classes. I'm planning on rebasing jan-dev on these changes so I can incorporate the split of the previous Participant class to two separate classes: User and Participant.

Files added:
- User.java: Added a User class that currently just has a User's username. In the future, this class will include preferences.

- UserDatastore.java: Added a UserDatastore class that stores Users to the datastore. In the future, this class will store each User's preferences and past matches.