### PR TITLE
Change JS lint npm commands to yarn commands

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install npm packages
-        run: npm install eslint@latest --save-dev
+        run: yarn add eslint@latest
       - name: Install eslint React Plugin
-        run: npm install eslint-plugin-react@latest --save-dev
+        run: yarn add eslint-plugin-react@latest
       - name: Install Google style plugin
-        run: npm install eslint-config-google@latest --save-dev
+        run: yarn add eslint-config-google@latest
       - name: Lint with ESLint
         run: ./node_modules/.bin/eslint frontend/**/*.js

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install npm packages
+      - name: Install yarn packages
         run: yarn add eslint@latest
       - name: Install eslint React Plugin
         run: yarn add eslint-plugin-react@latest


### PR DESCRIPTION
Files changed: 

- eslint.yaml: change npm installation commands to yarn add commands since our project utilizes yarn as its package manager. Essentially, this change ensures consistency within project, along with the added benefit of yarn's faster speed  and higher stability in comparison to npm. 