### PR TITLE
Add MVP fields to matching algorithm

### DIFF
--- a/backend/src/main/java/com/google/sps/FindMatchQuery.java
+++ b/backend/src/main/java/com/google/sps/FindMatchQuery.java
@@ -96,15 +96,16 @@ public final class FindMatchQuery {
    */
   private MatchPreference getCombinedMatchPreference(
       MatchPreference firstMatchPreference, MatchPreference secondMatchPreference) {
-    if ((firstMatchPreference != secondMatchPreference)
-        && (firstMatchPreference != MatchPreference.ANY)
-        && (secondMatchPreference != MatchPreference.ANY)) {
-      // One user is SIMILAR, other is DIFFERENT. Incompatible.
-      return null;
+    if (firstMatchPreference == secondMatchPreference) {
+      return firstMatchPreference;
     }
-    return (firstMatchPreference == MatchPreference.ANY)
-        ? secondMatchPreference
-        : firstMatchPreference;
+    if (firstMatchPreference == MatchPreference.ANY) {
+      return secondMatchPreference;
+    }
+    if (secondMatchPreference == MatchPreference.ANY) {
+      return firstMatchPreference;
+    }
+    return null;
   }
 
   /**

--- a/backend/src/main/java/com/google/sps/FindMatchQuery.java
+++ b/backend/src/main/java/com/google/sps/FindMatchQuery.java
@@ -136,7 +136,7 @@ public final class FindMatchQuery {
 
       // If match preference = similar, numSameFields must be at least MIN_SAME_FIELDS to satisfy
       // preference
-      // If match preference = differe, numSameFields must be less than MIN_SAME_FIELDS to satisfy
+      // If match preference = different, numSameFields must be less than MIN_SAME_FIELDS to satisfy
       // preference
       if ((combinedMatchPreference == MatchPreference.SIMILAR && numSameFields < MIN_SAME_FIELDS)
           || (combinedMatchPreference == MatchPreference.DIFFERENT

--- a/backend/src/main/java/com/google/sps/FindMatchQuery.java
+++ b/backend/src/main/java/com/google/sps/FindMatchQuery.java
@@ -105,7 +105,7 @@ public final class FindMatchQuery {
    *     any = both are any; different = both are different = one is different and one is any. or
    *     null if match preferences are not compatible
    */
-  private MatchPreference getCompatibleMatchPreference(
+  private MatchPreference getCombinedMatchPreference(
       MatchPreference firstMatchPreference, MatchPreference secondMatchPreference) {
     if ((firstMatchPreference == secondMatchPreference)
         || (firstMatchPreference == MatchPreference.ANY)
@@ -116,17 +116,6 @@ public final class FindMatchQuery {
     } else {
       return null;
     }
-  }
-
-  /**
-   * @return combined MatchPreference similar: both are similar, one is similar and one is any any:
-   *     both are any different: both are different, one is different and one is any
-   */
-  private MatchPreference getCombinedMatchPreference(
-      MatchPreference firstMatchPreference, MatchPreference secondMatchPreference) {
-    return (firstMatchPreference == MatchPreference.ANY)
-        ? secondMatchPreference
-        : firstMatchPreference;
   }
 
   /**

--- a/backend/src/main/java/com/google/sps/FindMatchQuery.java
+++ b/backend/src/main/java/com/google/sps/FindMatchQuery.java
@@ -15,6 +15,7 @@
 package com.google.sps;
 
 import com.google.sps.data.Match;
+import com.google.sps.data.MatchPreference;
 import com.google.sps.data.Participant;
 import com.google.sps.datastore.ParticipantDatastore;
 import java.time.Clock;
@@ -27,6 +28,8 @@ public final class FindMatchQuery {
 
   /** Extra padding time in minutes to ensure large enough meeting time block */
   private static final int PADDING_MINUTES = 10;
+  /** Minimum number of matching fields to be similar */
+  private static final int MIN_SAME_FIELDS = 1;
   /** Reference clock */
   private final Clock clock;
   /** Datastore of Participants */
@@ -54,26 +57,81 @@ public final class FindMatchQuery {
     long currentTimeMillis = clock.millis();
 
     long newEndTimeAvailable = newParticipant.getEndTimeAvailable();
+    MatchPreference newMatchPreference = newParticipant.getMatchPreference();
+    String newRole = newParticipant.getRole();
+    String newProductArea = newParticipant.getProductArea();
 
     // Compare new participant preferences with other participants to find match
     for (Participant currParticipant : sameDurationParticipants) {
       // Check if participants are both free for that duration + extra
       long currEndTimeAvailable = currParticipant.getEndTimeAvailable();
-      long earliestEndTimeAvailable = Math.min(newEndTimeAvailable, currEndTimeAvailable);
-      boolean compatibleTime =
-          (currentTimeMillis + TimeUnit.MINUTES.toMillis(duration + PADDING_MINUTES))
-              < earliestEndTimeAvailable;
-
-      if (compatibleTime) {
-        // Create and return match
-        return new Match(
-            newParticipant.getUsername(),
-            currParticipant.getUsername(),
-            duration,
-            currentTimeMillis);
+      if (!isCompatibleTime(
+          currentTimeMillis, duration, newEndTimeAvailable, currEndTimeAvailable)) {
+        System.out.println("not compatible time");
+        continue;
       }
+
+      // Check match preference compatibility and get combined preference if compatible
+      MatchPreference currMatchPreference = currParticipant.getMatchPreference();
+      if (!isCompatibleMatchPreference(newMatchPreference, currMatchPreference)) {
+        System.out.println("not compatible match pref");
+        continue;
+      }
+      MatchPreference combinedMatchPreference =
+          getCombinedMatchPreference(newMatchPreference, currMatchPreference);
+
+      if (combinedMatchPreference != MatchPreference.ANY) {
+        int numSameFields = getNumSameFields(newParticipant, currParticipant);
+        System.out.println(numSameFields);
+        if (combinedMatchPreference == MatchPreference.SIMILAR && numSameFields < MIN_SAME_FIELDS) {
+          continue;
+        } else if (combinedMatchPreference == MatchPreference.DIFFERENT
+            && numSameFields >= MIN_SAME_FIELDS) {
+          continue;
+        }
+      }
+      System.out.println("found a match");
+      return new Match(
+          newParticipant.getUsername(), currParticipant.getUsername(), duration, currentTimeMillis);
     }
     // No inital match found
     return null;
+  }
+
+  /** Return true if compatible endTimeAvailable considering duration and padding */
+  private boolean isCompatibleTime(
+      long currentTimeMillis, int duration, long newEndTimeAvailable, long currEndTimeAvailable) {
+    long earliestEndTimeAvailable = Math.min(newEndTimeAvailable, currEndTimeAvailable);
+    return (currentTimeMillis + TimeUnit.MINUTES.toMillis(duration + PADDING_MINUTES))
+        < earliestEndTimeAvailable;
+  }
+
+  /** Return true if compatible match preferences (same preference, one or both are any) */
+  private boolean isCompatibleMatchPreference(
+      MatchPreference newMatchPreference, MatchPreference currMatchPreference) {
+    return (newMatchPreference == currMatchPreference)
+        || (newMatchPreference == MatchPreference.ANY)
+        || (currMatchPreference == MatchPreference.ANY);
+  }
+
+  /**
+   * @return combined MatchPreference similar: both are similar, one is similar and one is any any:
+   *     both are any different: both are different, one is different and one is any
+   */
+  private MatchPreference getCombinedMatchPreference(
+      MatchPreference newMatchPreference, MatchPreference currMatchPreference) {
+    return (newMatchPreference == MatchPreference.ANY) ? currMatchPreference : newMatchPreference;
+  }
+
+  /** Return the number of fields that both participants have in common */
+  private int getNumSameFields(Participant newParticipant, Participant currParticipant) {
+    int numSameFields = 0;
+    if (newParticipant.getRole().equals(currParticipant.getRole())) {
+      numSameFields++;
+    }
+    if (newParticipant.getProductArea().equals(currParticipant.getProductArea())) {
+      numSameFields++;
+    }
+    return numSameFields;
   }
 }

--- a/backend/src/main/java/com/google/sps/data/Match.java
+++ b/backend/src/main/java/com/google/sps/data/Match.java
@@ -20,6 +20,7 @@ public final class Match {
       String secondParticipantUsername,
       int duration,
       long timestamp) {
+    // TODO (#58): Add shared interests
     this.firstParticipantUsername = firstParticipantUsername;
     this.secondParticipantUsername = secondParticipantUsername;
     this.duration = duration;

--- a/backend/src/main/java/com/google/sps/data/Match.java
+++ b/backend/src/main/java/com/google/sps/data/Match.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 import com.google.common.base.MoreObjects;

--- a/backend/src/main/java/com/google/sps/data/MatchPreference.java
+++ b/backend/src/main/java/com/google/sps/data/MatchPreference.java
@@ -17,11 +17,11 @@ package com.google.sps.data;
 /** Represent whether or not a Participant is matched */
 public enum MatchPreference {
   /** Prefer to be matched with different Googler */
-  DIFFERENT(-1),
+  DIFFERENT(0),
   /** No preference on match similarity */
-  ANY(0),
+  ANY(1),
   /** Prefer to be matched with similar Googler */
-  SIMILAR(1);
+  SIMILAR(2);
 
   private final int value;
 

--- a/backend/src/main/java/com/google/sps/data/MatchPreference.java
+++ b/backend/src/main/java/com/google/sps/data/MatchPreference.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 /** Represent whether or not a Participant is matched */

--- a/backend/src/main/java/com/google/sps/data/MatchPreference.java
+++ b/backend/src/main/java/com/google/sps/data/MatchPreference.java
@@ -1,0 +1,30 @@
+package com.google.sps.data;
+
+/** Represent whether or not a Participant is matched */
+public enum MatchPreference {
+  /** Prefer to be matched with different Googler */
+  DIFFERENT(-1),
+  /** No preference on match similarity */
+  ANY(0),
+  /** Prefer to be matched with similar Googler */
+  SIMILAR(1);
+
+  private final int value;
+
+  MatchPreference(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public static MatchPreference forIntValue(int value) {
+    for (MatchPreference preference : MatchPreference.values()) {
+      if (preference.value == value) {
+        return preference;
+      }
+    }
+    throw new IllegalStateException("Unknown enum value.");
+  }
+}

--- a/backend/src/main/java/com/google/sps/data/MatchStatus.java
+++ b/backend/src/main/java/com/google/sps/data/MatchStatus.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 /** Represent whether or not a Participant is matched */

--- a/backend/src/main/java/com/google/sps/data/MatchStatus.java
+++ b/backend/src/main/java/com/google/sps/data/MatchStatus.java
@@ -18,7 +18,6 @@ public enum MatchStatus {
   }
 
   public static MatchStatus forIntValue(int value) {
-    System.out.println(value);
     for (MatchStatus status : MatchStatus.values()) {
       if (status.value == value) {
         return status;

--- a/backend/src/main/java/com/google/sps/data/Participant.java
+++ b/backend/src/main/java/com/google/sps/data/Participant.java
@@ -19,7 +19,7 @@ public final class Participant {
   /** Product area at Google */
   private final String productArea;
   /** Whether they want to be matched with a similar, any, or different Googler */
-  private final String matchPreference;
+  private final MatchPreference matchPreference;
   /** Id of match in datastore, 0 if never found a match (can assign 0 at construction) */
   private final long matchId;
   /** Matched already or not yet */
@@ -35,7 +35,7 @@ public final class Participant {
       int duration,
       String role,
       String productArea,
-      String matchPreference,
+      MatchPreference matchPreference,
       long matchId,
       MatchStatus matchStatus,
       long timestamp) {
@@ -78,7 +78,7 @@ public final class Participant {
     return productArea;
   }
 
-  public String getMatchPreference() {
+  public MatchPreference getMatchPreference() {
     return matchPreference;
   }
 
@@ -101,6 +101,9 @@ public final class Participant {
         startTimeAvailable,
         endTimeAvailable,
         duration,
+        role,
+        productArea,
+        matchPreference,
         newMatchId,
         MatchStatus.MATCHED,
         timestamp);
@@ -112,6 +115,9 @@ public final class Participant {
         .add("startTimeAvailable", startTimeAvailable)
         .add("endTimeAvailable", endTimeAvailable)
         .add("duration", duration)
+        .add("role", role)
+        .add("productArea", productArea)
+        .add("matchPreference", matchPreference.getValue())
         .add("matchId", matchId)
         .add("matchStatus", matchStatus.getValue())
         .add("timestamp", timestamp)

--- a/backend/src/main/java/com/google/sps/data/Participant.java
+++ b/backend/src/main/java/com/google/sps/data/Participant.java
@@ -14,6 +14,12 @@ public final class Participant {
   private final long endTimeAvailable;
   /** How long user wants to chat */
   private final int duration;
+  /** Role at Google */
+  private final String role;
+  /** Product area at Google */
+  private final String productArea;
+  /** Whether they want to be matched with a similar, any, or different Googler */
+  private final String matchPreference;
   /** Id of match in datastore, 0 if never found a match (can assign 0 at construction) */
   private final long matchId;
   /** Matched already or not yet */
@@ -27,6 +33,9 @@ public final class Participant {
       long startTimeAvailable,
       long endTimeAvailable,
       int duration,
+      String role,
+      String productArea,
+      String matchPreference,
       long matchId,
       MatchStatus matchStatus,
       long timestamp) {
@@ -37,6 +46,9 @@ public final class Participant {
     this.startTimeAvailable = startTimeAvailable;
     this.endTimeAvailable = endTimeAvailable;
     this.duration = duration;
+    this.role = role;
+    this.productArea = productArea;
+    this.matchPreference = matchPreference;
     this.matchId = matchId;
     this.matchStatus = matchStatus;
     this.timestamp = timestamp;
@@ -56,6 +68,18 @@ public final class Participant {
 
   public int getDuration() {
     return duration;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public String getProductArea() {
+    return productArea;
+  }
+
+  public String getMatchPreference() {
+    return matchPreference;
   }
 
   public long getMatchId() {

--- a/backend/src/main/java/com/google/sps/data/Participant.java
+++ b/backend/src/main/java/com/google/sps/data/Participant.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 import com.google.common.base.MoreObjects;

--- a/backend/src/main/java/com/google/sps/data/User.java
+++ b/backend/src/main/java/com/google/sps/data/User.java
@@ -5,27 +5,58 @@ import com.google.common.base.MoreObjects;
 /** A user with saved preferences. */
 public final class User {
 
-  /** Datastore ID */
-  private final long id;
   /** Google username (ldap) */
   private final String username;
+  /** How long user wants to chat */
+  private final int duration;
+  /** Role at Google */
+  private final String role;
+  /** Product area at Google */
+  private final String productArea;
+  /** Whether they want to be matched with a similar, any, or different Googler */
+  private final MatchPreference matchPreference;
 
   /** Initialize constructor fields */
-  public User(long id, String username) {
-    // TODO(#32): add User interests
-    this.id = id;
+  public User(
+      String username,
+      int duration,
+      String role,
+      String productArea,
+      MatchPreference matchPreference) {
     this.username = username;
-  }
-
-  public long getId() {
-    return id;
+    this.duration = duration;
+    this.role = role;
+    this.productArea = productArea;
+    this.matchPreference = matchPreference;
   }
 
   public String getUsername() {
     return username;
   }
 
+  public int getDuration() {
+    return duration;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public String getProductArea() {
+    return productArea;
+  }
+
+  public MatchPreference getMatchPreference() {
+    return matchPreference;
+  }
+
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("id", id).add("username", username).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("username", username)
+        .add("duration", duration)
+        .add("role", role)
+        .add("productArea", productArea)
+        .add("matchPreference", matchPreference.getValue())
+        .toString();
   }
 }

--- a/backend/src/main/java/com/google/sps/data/User.java
+++ b/backend/src/main/java/com/google/sps/data/User.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.data;
 
 import com.google.common.base.MoreObjects;

--- a/backend/src/main/java/com/google/sps/data/User.java
+++ b/backend/src/main/java/com/google/sps/data/User.java
@@ -21,7 +21,7 @@ public final class User {
 
   /** Google username (ldap) */
   private final String username;
-  /** How long user wants to chat */
+  /** How long user prefers to chat */
   private final int duration;
   /** Role at Google */
   private final String role;

--- a/backend/src/main/java/com/google/sps/datastore/MatchDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/MatchDatastore.java
@@ -41,8 +41,8 @@ public final class MatchDatastore {
     this.datastore = datastore;
   }
 
-  /** Return entity of match */
-  private static Entity getEntityFromMatch(Match match) {
+  /** Return entity created from match */
+  private static Entity createEntityFromMatch(Match match) {
     // Set properties of entity
     Entity entity = new Entity(KIND_MATCH);
     entity.setProperty(PROPERTY_FIRST_PARTICIPANT_USERNAME, match.getFirstParticipantUsername());
@@ -55,7 +55,7 @@ public final class MatchDatastore {
   /** Put Match in datastore and return the match key id */
   public long addMatch(Match match) {
     // Create and insert entity into datastore
-    Entity entity = getEntityFromMatch(match);
+    Entity entity = createEntityFromMatch(match);
     datastore.put(entity);
 
     // Return match key id

--- a/backend/src/main/java/com/google/sps/datastore/MatchDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/MatchDatastore.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.datastore;
 
 import com.google.appengine.api.datastore.DatastoreService;

--- a/backend/src/main/java/com/google/sps/datastore/ParticipantDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/ParticipantDatastore.java
@@ -10,6 +10,7 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.sps.data.MatchPreference;
 import com.google.sps.data.MatchStatus;
 import com.google.sps.data.Participant;
 import java.util.ArrayList;
@@ -26,6 +27,9 @@ public final class ParticipantDatastore {
   private static final String PROPERTY_START_TIME_AVAILABLE = "startTimeAvailable";
   private static final String PROPERTY_END_TIME_AVAILABLE = "endTimeAvailable";
   private static final String PROPERTY_DURATION = "duration";
+  private static final String PROPERTY_ROLE = "role";
+  private static final String PROPERTY_PRODUCT_AREA = "productArea";
+  private static final String PROPERTY_MATCH_PREFERENCE = "matchPreference";
   private static final String PROPERTY_MATCH_ID = "matchId";
   private static final String PROPERTY_MATCH_STATUS = "matchStatus";
   private static final String PROPERTY_TIMESTAMP = "timestamp";
@@ -46,6 +50,9 @@ public final class ParticipantDatastore {
     entity.setProperty(PROPERTY_START_TIME_AVAILABLE, participant.getStartTimeAvailable());
     entity.setProperty(PROPERTY_END_TIME_AVAILABLE, participant.getEndTimeAvailable());
     entity.setProperty(PROPERTY_DURATION, participant.getDuration());
+    entity.setProperty(PROPERTY_ROLE, participant.getRole());
+    entity.setProperty(PROPERTY_PRODUCT_AREA, participant.getProductArea());
+    entity.setProperty(PROPERTY_MATCH_PREFERENCE, participant.getMatchPreference().getValue());
     entity.setProperty(PROPERTY_MATCH_ID, participant.getMatchId());
     entity.setProperty(PROPERTY_MATCH_STATUS, participant.getMatchStatus().getValue());
     entity.setProperty(PROPERTY_TIMESTAMP, participant.getTimestamp());
@@ -81,6 +88,10 @@ public final class ParticipantDatastore {
         (long) entity.getProperty(PROPERTY_START_TIME_AVAILABLE),
         (long) entity.getProperty(PROPERTY_END_TIME_AVAILABLE),
         ((Long) entity.getProperty(PROPERTY_DURATION)).intValue(),
+        (String) entity.getProperty(PROPERTY_ROLE),
+        (String) entity.getProperty(PROPERTY_PRODUCT_AREA),
+        MatchPreference.forIntValue(
+            ((Long) entity.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()),
         (long) entity.getProperty(PROPERTY_MATCH_ID),
         MatchStatus.forIntValue(((Long) entity.getProperty(PROPERTY_MATCH_STATUS)).intValue()),
         (long) entity.getProperty(PROPERTY_TIMESTAMP));

--- a/backend/src/main/java/com/google/sps/datastore/ParticipantDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/ParticipantDatastore.java
@@ -56,8 +56,8 @@ public final class ParticipantDatastore {
     this.datastore = datastore;
   }
 
-  /** Return entity of participant */
-  private static Entity getEntityFromParticipant(Participant participant) {
+  /** Return entity created from participant */
+  private static Entity createEntityFromParticipant(Participant participant) {
     // Set properties of entity based on participant fields
     Entity entity = new Entity(KIND_PARTICIPANT, participant.getUsername());
     entity.setProperty(PROPERTY_USERNAME, participant.getUsername());
@@ -80,7 +80,7 @@ public final class ParticipantDatastore {
    */
   public void addParticipant(Participant participant) {
     // Insert entity into datastore
-    datastore.put(getEntityFromParticipant(participant));
+    datastore.put(createEntityFromParticipant(participant));
   }
 
   /** Return Participant Entity from username, or null if entity is not found */

--- a/backend/src/main/java/com/google/sps/datastore/ParticipantDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/ParticipantDatastore.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.datastore;
 
 import com.google.appengine.api.datastore.DatastoreService;

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -43,8 +43,8 @@ public final class UserDatastore {
     this.datastore = datastore;
   }
 
-  /** Put user in datastore. Overwrite user entity if user with same username already exists. */
-  public void addUser(User user) {
+  /** Return entity of user */
+  private Entity getEntityFromUser(User user) {
     // Set properties of entity based on user fields
     Entity entity = new Entity(KIND_USER, user.getUsername());
     entity.setProperty(PROPERTY_USERNAME, user.getUsername());
@@ -53,8 +53,14 @@ public final class UserDatastore {
     entity.setProperty(PROPERTY_PRODUCT_AREA, user.getProductArea());
     entity.setProperty(PROPERTY_MATCH_PREFERENCE, user.getMatchPreference().getValue());
 
+    return entity;
+  }
+
+  /** Put user in datastore. Overwrite user entity if user with same username already exists. */
+  public void addUser(User user) {
+    ;
     // Insert entity into datastore
-    datastore.put(entity);
+    datastore.put(getEntityFromUser(user));
   }
 
   /** Return User Entity from username, or null if entity is not found */

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -43,8 +43,8 @@ public final class UserDatastore {
     this.datastore = datastore;
   }
 
-  /** Return entity of user */
-  private Entity getEntityFromUser(User user) {
+  /** Return entity created from user */
+  private Entity createEntityFromUser(User user) {
     // Set properties of entity based on user fields
     Entity entity = new Entity(KIND_USER, user.getUsername());
     entity.setProperty(PROPERTY_USERNAME, user.getUsername());
@@ -60,7 +60,7 @@ public final class UserDatastore {
   public void addUser(User user) {
     ;
     // Insert entity into datastore
-    datastore.put(getEntityFromUser(user));
+    datastore.put(createEntityFromUser(user));
   }
 
   /** Return User Entity from username, or null if entity is not found */

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -58,7 +58,6 @@ public final class UserDatastore {
 
   /** Put user in datastore. Overwrite user entity if user with same username already exists. */
   public void addUser(User user) {
-    ;
     // Insert entity into datastore
     datastore.put(createEntityFromUser(user));
   }

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.sps.datastore;
 
 import com.google.appengine.api.datastore.DatastoreService;

--- a/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
+++ b/backend/src/main/java/com/google/sps/datastore/UserDatastore.java
@@ -5,6 +5,7 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.sps.data.MatchPreference;
 import com.google.sps.data.User;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,6 +16,10 @@ public final class UserDatastore {
   // Datastore Key/Property constants
   private static final String KIND_USER = "User";
   private static final String PROPERTY_USERNAME = "username";
+  private static final String PROPERTY_DURATION = "duration";
+  private static final String PROPERTY_ROLE = "role";
+  private static final String PROPERTY_PRODUCT_AREA = "productArea";
+  private static final String PROPERTY_MATCH_PREFERENCE = "matchPreference";
 
   /** Datastore */
   private final DatastoreService datastore;
@@ -27,11 +32,15 @@ public final class UserDatastore {
   /** Put user in datastore. Overwrite user entity if user with same username already exists. */
   public void addUser(User user) {
     // Set properties of entity based on user fields
-    Entity userEntity = new Entity(KIND_USER, user.getUsername());
-    userEntity.setProperty(PROPERTY_USERNAME, user.getUsername());
+    Entity entity = new Entity(KIND_USER, user.getUsername());
+    entity.setProperty(PROPERTY_USERNAME, user.getUsername());
+    entity.setProperty(PROPERTY_DURATION, user.getDuration());
+    entity.setProperty(PROPERTY_ROLE, user.getRole());
+    entity.setProperty(PROPERTY_PRODUCT_AREA, user.getProductArea());
+    entity.setProperty(PROPERTY_MATCH_PREFERENCE, user.getMatchPreference().getValue());
 
     // Insert entity into datastore
-    datastore.put(userEntity);
+    datastore.put(entity);
   }
 
   /** Return User Entity from username, or null if entity is not found */
@@ -48,12 +57,13 @@ public final class UserDatastore {
   /** Return user object from datastore user entity, or null if entity is null */
   @Nullable
   private static User getUserFromEntity(@Nonnull Entity entity) {
-    // Get entity properties
-    long id = (long) entity.getKey().getId();
-    String username = (String) entity.getProperty(PROPERTY_USERNAME);
-
-    // Create and return new User
-    return new User(id, username);
+    return new User(
+        (String) entity.getProperty(PROPERTY_USERNAME),
+        ((Long) entity.getProperty(PROPERTY_DURATION)).intValue(),
+        (String) entity.getProperty(PROPERTY_ROLE),
+        (String) entity.getProperty(PROPERTY_PRODUCT_AREA),
+        MatchPreference.forIntValue(
+            ((Long) entity.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()));
   }
 
   /** Return User from username, or null if user with username not in datastore */

--- a/backend/src/main/java/com/google/sps/servlets/AddParticipantServlet.java
+++ b/backend/src/main/java/com/google/sps/servlets/AddParticipantServlet.java
@@ -20,10 +20,13 @@ import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.sps.FindMatchQuery;
 import com.google.sps.data.Match;
+import com.google.sps.data.MatchPreference;
 import com.google.sps.data.MatchStatus;
 import com.google.sps.data.Participant;
+import com.google.sps.data.User;
 import com.google.sps.datastore.MatchDatastore;
 import com.google.sps.datastore.ParticipantDatastore;
+import com.google.sps.datastore.UserDatastore;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.time.Clock;
@@ -68,7 +71,19 @@ public class AddParticipantServlet extends HttpServlet {
     String role = formDetails.getString(REQUEST_ROLE);
     String productArea = formDetails.getString(REQUEST_PRODUCT_AREA);
     boolean savePreference = formDetails.getBoolean(REQUEST_SAVE_PREFERENCE);
-    String matchPreference = formDetails.getString(REQUEST_MATCH_PREFERENCE);
+    String matchPreferenceString = formDetails.getString(REQUEST_MATCH_PREFERENCE);
+    MatchPreference matchPreference = MatchPreference.ANY;
+    switch (matchPreferenceString) {
+      case "different":
+        matchPreference = MatchPreference.DIFFERENT;
+        break;
+      case "any":
+        matchPreference = MatchPreference.ANY;
+        break;
+      case "similar":
+        matchPreference = MatchPreference.SIMILAR;
+        break;
+    }
     long timestamp = System.currentTimeMillis();
 
     String username = getUsername();
@@ -84,6 +99,9 @@ public class AddParticipantServlet extends HttpServlet {
             startTimeAvailable,
             endTimeAvailable,
             duration,
+            role,
+            productArea,
+            matchPreference,
             /* matchId=*/ 0,
             MatchStatus.UNMATCHED,
             timestamp);
@@ -92,6 +110,7 @@ public class AddParticipantServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     MatchDatastore matchDatastore = new MatchDatastore(datastore);
     ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    UserDatastore userDatastore = new UserDatastore(datastore);
 
     // Check if new participant already in datastore (unmatched, in queue)
     // TODO: FIX! What if matched but not returned yet
@@ -99,6 +118,12 @@ public class AddParticipantServlet extends HttpServlet {
     if (existingParticipant != null) {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Already submitted form");
       return;
+    }
+
+    // Add User to datastore if opted to save preferences
+    if (savePreference) {
+      User user = new User(username, duration, role, productArea, matchPreference);
+      userDatastore.addUser(user);
     }
 
     // Find immediate match if possible

--- a/backend/src/main/java/com/google/sps/servlets/AddParticipantServlet.java
+++ b/backend/src/main/java/com/google/sps/servlets/AddParticipantServlet.java
@@ -72,7 +72,7 @@ public class AddParticipantServlet extends HttpServlet {
     String productArea = formDetails.getString(REQUEST_PRODUCT_AREA);
     boolean savePreference = formDetails.getBoolean(REQUEST_SAVE_PREFERENCE);
     String matchPreferenceString = formDetails.getString(REQUEST_MATCH_PREFERENCE);
-    MatchPreference matchPreference = MatchPreference.ANY;
+    MatchPreference matchPreference;
     switch (matchPreferenceString) {
       case "different":
         matchPreference = MatchPreference.DIFFERENT;
@@ -83,6 +83,9 @@ public class AddParticipantServlet extends HttpServlet {
       case "similar":
         matchPreference = MatchPreference.SIMILAR;
         break;
+      default:
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid match preference.");
+        return;
     }
     long timestamp = System.currentTimeMillis();
 

--- a/backend/src/main/java/com/google/sps/servlets/SearchMatchServlet.java
+++ b/backend/src/main/java/com/google/sps/servlets/SearchMatchServlet.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.json.simple.JSONObject;
 
-/** Servlet that searches for the participant's current match */
+/** Servlet that searches for the participant's current match and removes participant if expired */
 @WebServlet("/api/v1/search-match")
 public class SearchMatchServlet extends HttpServlet {
 

--- a/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
+++ b/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
@@ -579,7 +579,7 @@ public final class FindMatchQueryTest {
   @Test
   public void oneFieldMatches() {
     // Two participants with one matching field prefer to be matched with someone similar
-    // TODO: change num matching fields threshold when interests are added
+    // TODO (#67): change num matching fields threshold when interests are added
     Participant participantA =
         new Participant(
             PERSON_A,

--- a/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
+++ b/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
@@ -21,6 +21,7 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.sps.data.Match;
+import com.google.sps.data.MatchPreference;
 import com.google.sps.data.MatchStatus;
 import com.google.sps.data.Participant;
 import com.google.sps.datastore.ParticipantDatastore;
@@ -45,6 +46,19 @@ public final class FindMatchQueryTest {
   // Default parameters unused in query
   private static final long MATCHID_DEFAULT = 0;
   private static final long TIMESTAMP_DEFAULT = 0;
+
+  // Role constants
+  private static final String ROLE_SOFTWARE_ENGINEER = "Software engineer";
+  private static final String ROLE_PRODUCT_MANAGER = "Product manager";
+
+  // Product area constants
+  private static final String PRODUCT_AREA_ADS = "Ads";
+  private static final String PRODUCT_AREA_CLOUD = "Cloud";
+
+  // Match preference constants
+  private static final MatchPreference MATCH_PREFERENCE_DIFFERENT = MatchPreference.DIFFERENT;
+  private static final MatchPreference MATCH_PREFERENCE_ANY = MatchPreference.ANY;
+  private static final MatchPreference MATCH_PREFERENCE_SIMILAR = MatchPreference.SIMILAR;
 
   // Duration constants
   private static final int DURATION_15_MINUTES = 15;
@@ -112,6 +126,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1600ET,
             DURATION_15_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -121,6 +138,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1800ET,
             DURATION_15_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -145,6 +165,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1600ET,
             DURATION_30_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -154,6 +177,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1800ET,
             DURATION_60_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -176,6 +202,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1450ET,
             DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -185,6 +214,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1600ET,
             DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -207,6 +239,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1600ET,
             DURATION_60_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -216,6 +251,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1450ET,
             DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -225,6 +263,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1800ET,
             DURATION_60_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -250,6 +291,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1450ET,
             DURATION_30_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -259,6 +303,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1600ET,
             DURATION_60_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -268,6 +315,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1800ET,
             DURATION_60_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -293,6 +343,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1600ET,
             DURATION_30_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -302,6 +355,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1800ET,
             DURATION_30_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -311,6 +367,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_2000ET,
             DURATION_30_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -336,6 +395,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1455ET,
             DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -345,6 +407,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1800ET,
             DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -368,6 +433,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1456ET,
             DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);
@@ -377,6 +445,9 @@ public final class FindMatchQueryTest {
             TIME_1400ET,
             TIME_1800ET,
             DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
             MATCHID_DEFAULT,
             MATCHSTATUS_UNMATCHED,
             TIMESTAMP_DEFAULT);

--- a/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
+++ b/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
@@ -462,4 +462,157 @@ public final class FindMatchQueryTest {
     assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
     assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
   }
+
+  @Test
+  public void areDifferentPreferSimilar() {
+    // Two participants that are different but prefer to be matched with someone similar
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_PRODUCT_MANAGER,
+            PRODUCT_AREA_CLOUD,
+            MATCH_PREFERENCE_SIMILAR,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match).isNull();
+  }
+
+  @Test
+  public void areSimilarPreferDifferent() {
+    // Two participants that are similar but prefer to be matched with someone different
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_DIFFERENT,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_DIFFERENT,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match).isNull();
+  }
+
+  @Test
+  public void areDifferentPreferDifferent() {
+    // Two participants that are different and prefer to be matched with someone different
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_DIFFERENT,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_PRODUCT_MANAGER,
+            PRODUCT_AREA_CLOUD,
+            MATCH_PREFERENCE_DIFFERENT,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match.getFirstParticipantUsername()).isEqualTo(PERSON_B);
+    assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
+    assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
+  }
+
+  @Test
+  public void oneFieldMatches() {
+    // Two participants with one matching field prefer to be matched with someone similar
+    // TODO: change num matching fields threshold when interests are added
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_PRODUCT_MANAGER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match.getFirstParticipantUsername()).isEqualTo(PERSON_B);
+    assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
+    assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
+  }
 }

--- a/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
+++ b/backend/src/test/java/com/google/sps/FindMatchQueryTest.java
@@ -615,4 +615,160 @@ public final class FindMatchQueryTest {
     assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
     assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
   }
+
+  @Test
+  public void areSimilarPreferSimilarAny() {
+    // Two participants that are similar, one prefers similar, other has no preference
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_SIMILAR,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_ANY,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match.getFirstParticipantUsername()).isEqualTo(PERSON_B);
+    assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
+    assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
+  }
+
+  @Test
+  public void areDifferentPreferDifferentAny() {
+    // Two participants that are different, one prefers different, other has no preference
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_DIFFERENT,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_PRODUCT_MANAGER,
+            PRODUCT_AREA_CLOUD,
+            MATCH_PREFERENCE_ANY,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match.getFirstParticipantUsername()).isEqualTo(PERSON_B);
+    assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
+    assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
+  }
+
+  @Test
+  public void areDifferentNoPreference() {
+    // Two participants that are different but both have no preference
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_ANY,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_PRODUCT_MANAGER,
+            PRODUCT_AREA_CLOUD,
+            MATCH_PREFERENCE_ANY,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match.getFirstParticipantUsername()).isEqualTo(PERSON_B);
+    assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
+    assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
+  }
+
+  @Test
+  public void areSimilarNoPreference() {
+    // Two participants that are similar but both have no preference
+    Participant participantA =
+        new Participant(
+            PERSON_A,
+            TIME_1400ET,
+            TIME_1456ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_ANY,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    Participant participantB =
+        new Participant(
+            PERSON_B,
+            TIME_1400ET,
+            TIME_1800ET,
+            DURATION_45_MINUTES,
+            ROLE_SOFTWARE_ENGINEER,
+            PRODUCT_AREA_ADS,
+            MATCH_PREFERENCE_ANY,
+            MATCHID_DEFAULT,
+            MATCHSTATUS_UNMATCHED,
+            TIMESTAMP_DEFAULT);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    ParticipantDatastore participantDatastore = new ParticipantDatastore(datastore);
+    participantDatastore.addParticipant(participantA);
+
+    FindMatchQuery query = new FindMatchQuery(clock, participantDatastore);
+    Match match = query.findMatch(participantB);
+
+    assertThat(match.getFirstParticipantUsername()).isEqualTo(PERSON_B);
+    assertThat(match.getSecondParticipantUsername()).isEqualTo(PERSON_A);
+    assertThat(match.getDuration()).isEqualTo(DURATION_45_MINUTES);
+  }
 }

--- a/backend/src/test/java/com/google/sps/ParticipantDatastoreTest.java
+++ b/backend/src/test/java/com/google/sps/ParticipantDatastoreTest.java
@@ -24,6 +24,7 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.sps.data.MatchPreference;
 import com.google.sps.data.MatchStatus;
 import com.google.sps.data.Participant;
 import com.google.sps.datastore.ParticipantDatastore;
@@ -38,11 +39,13 @@ import org.junit.runners.JUnit4;
 public final class ParticipantDatastoreTest {
 
   // Default values
-  private static final long ID_DEFAULT = 123456;
   private static final long START_TIME_AVAILABLE_DEFAULT = 0;
   private static final long END_TIME_AVAILABLE_DEFAULT =
       ZonedDateTime.now().toInstant().toEpochMilli();
   private static final int DURATION_DEFAULT = 30;
+  private static final String ROLE_DEFAULT = "Software engineer";
+  private static final String PRODUCT_AREA_DEFAULT = "Ads";
+  private static final MatchPreference MATCH_PREFERENCE_DEFAULT = MatchPreference.SIMILAR;
   private static final long MATCH_ID_DEFAULT = 0;
   private static final MatchStatus MATCH_STATUS_DEFAULT = MatchStatus.UNMATCHED;
   private static final long TIMESTAMP_DEFAULT = 0;
@@ -59,6 +62,9 @@ public final class ParticipantDatastoreTest {
   private static final String PROPERTY_START_TIME_AVAILABLE = "startTimeAvailable";
   private static final String PROPERTY_END_TIME_AVAILABLE = "endTimeAvailable";
   private static final String PROPERTY_DURATION = "duration";
+  private static final String PROPERTY_ROLE = "role";
+  private static final String PROPERTY_PRODUCT_AREA = "productArea";
+  private static final String PROPERTY_MATCH_PREFERENCE = "matchPreference";
   private static final String PROPERTY_MATCH_ID = "matchId";
   private static final String PROPERTY_MATCH_STATUS = "matchStatus";
   private static final String PROPERTY_TIMESTAMP = "timestamp";
@@ -88,6 +94,9 @@ public final class ParticipantDatastoreTest {
             START_TIME_AVAILABLE_DEFAULT,
             END_TIME_AVAILABLE_DEFAULT,
             DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT,
             MATCH_ID_DEFAULT,
             MATCH_STATUS_DEFAULT,
             TIMESTAMP_DEFAULT);
@@ -103,6 +112,12 @@ public final class ParticipantDatastoreTest {
         .isEqualTo(END_TIME_AVAILABLE_DEFAULT);
     assertThat(((Long) entity.getProperty(PROPERTY_DURATION)).intValue())
         .isEqualTo(DURATION_DEFAULT);
+    assertThat((String) entity.getProperty(PROPERTY_ROLE)).isEqualTo(ROLE_DEFAULT);
+    assertThat((String) entity.getProperty(PROPERTY_PRODUCT_AREA)).isEqualTo(PRODUCT_AREA_DEFAULT);
+    assertThat(
+            MatchPreference.forIntValue(
+                ((Long) entity.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()))
+        .isEqualTo(MATCH_PREFERENCE_DEFAULT);
     assertThat((long) entity.getProperty(PROPERTY_MATCH_ID)).isEqualTo(MATCH_ID_DEFAULT);
     assertThat(
             MatchStatus.forIntValue(((Long) entity.getProperty(PROPERTY_MATCH_STATUS)).intValue()))
@@ -121,6 +136,9 @@ public final class ParticipantDatastoreTest {
             START_TIME_AVAILABLE_DEFAULT,
             END_TIME_AVAILABLE_DEFAULT,
             DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT,
             MATCH_ID_DEFAULT,
             MATCH_STATUS_DEFAULT,
             TIMESTAMP_DEFAULT);
@@ -130,6 +148,9 @@ public final class ParticipantDatastoreTest {
             START_TIME_AVAILABLE_DEFAULT,
             END_TIME_AVAILABLE_DEFAULT,
             DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT,
             MATCH_ID_DEFAULT,
             MATCH_STATUS_DEFAULT,
             TIMESTAMP_DEFAULT);
@@ -148,6 +169,12 @@ public final class ParticipantDatastoreTest {
         .isEqualTo(END_TIME_AVAILABLE_DEFAULT);
     assertThat(((Long) entityA.getProperty(PROPERTY_DURATION)).intValue())
         .isEqualTo(DURATION_DEFAULT);
+    assertThat((String) entityA.getProperty(PROPERTY_ROLE)).isEqualTo(ROLE_DEFAULT);
+    assertThat((String) entityA.getProperty(PROPERTY_PRODUCT_AREA)).isEqualTo(PRODUCT_AREA_DEFAULT);
+    assertThat(
+            MatchPreference.forIntValue(
+                ((Long) entityA.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()))
+        .isEqualTo(MATCH_PREFERENCE_DEFAULT);
     assertThat((long) entityA.getProperty(PROPERTY_MATCH_ID)).isEqualTo(MATCH_ID_DEFAULT);
     assertThat(
             MatchStatus.forIntValue(((Long) entityA.getProperty(PROPERTY_MATCH_STATUS)).intValue()))
@@ -160,6 +187,12 @@ public final class ParticipantDatastoreTest {
         .isEqualTo(END_TIME_AVAILABLE_DEFAULT);
     assertThat(((Long) entityB.getProperty(PROPERTY_DURATION)).intValue())
         .isEqualTo(DURATION_DEFAULT);
+    assertThat((String) entityB.getProperty(PROPERTY_ROLE)).isEqualTo(ROLE_DEFAULT);
+    assertThat((String) entityB.getProperty(PROPERTY_PRODUCT_AREA)).isEqualTo(PRODUCT_AREA_DEFAULT);
+    assertThat(
+            MatchPreference.forIntValue(
+                ((Long) entityB.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()))
+        .isEqualTo(MATCH_PREFERENCE_DEFAULT);
     assertThat((long) entityB.getProperty(PROPERTY_MATCH_ID)).isEqualTo(MATCH_ID_DEFAULT);
     assertThat(
             MatchStatus.forIntValue(((Long) entityB.getProperty(PROPERTY_MATCH_STATUS)).intValue()))
@@ -178,6 +211,9 @@ public final class ParticipantDatastoreTest {
             START_TIME_AVAILABLE_DEFAULT,
             END_TIME_AVAILABLE_DEFAULT,
             DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT,
             MATCH_ID_DEFAULT,
             MATCH_STATUS_DEFAULT,
             TIMESTAMP_DEFAULT);
@@ -190,6 +226,9 @@ public final class ParticipantDatastoreTest {
         .isEqualTo(START_TIME_AVAILABLE_DEFAULT);
     assertThat(participantFromUsername.getEndTimeAvailable()).isEqualTo(END_TIME_AVAILABLE_DEFAULT);
     assertThat(participantFromUsername.getDuration()).isEqualTo(DURATION_DEFAULT);
+    assertThat(participantFromUsername.getRole()).isEqualTo(ROLE_DEFAULT);
+    assertThat(participantFromUsername.getProductArea()).isEqualTo(PRODUCT_AREA_DEFAULT);
+    assertThat(participantFromUsername.getMatchPreference()).isEqualTo(MATCH_PREFERENCE_DEFAULT);
     assertThat(participantFromUsername.getMatchId()).isEqualTo(MATCH_ID_DEFAULT);
     assertThat(participantFromUsername.getMatchStatus()).isEqualTo(MATCH_STATUS_DEFAULT);
     assertThat(participantFromUsername.getTimestamp()).isEqualTo(TIMESTAMP_DEFAULT);
@@ -206,6 +245,9 @@ public final class ParticipantDatastoreTest {
             START_TIME_AVAILABLE_DEFAULT,
             END_TIME_AVAILABLE_DEFAULT,
             DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT,
             MATCH_ID_DEFAULT,
             MATCH_STATUS_DEFAULT,
             TIMESTAMP_DEFAULT);
@@ -225,6 +267,9 @@ public final class ParticipantDatastoreTest {
             START_TIME_AVAILABLE_DEFAULT,
             END_TIME_AVAILABLE_DEFAULT,
             DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT,
             MATCH_ID_DEFAULT,
             MATCH_STATUS_DEFAULT,
             TIMESTAMP_DEFAULT);

--- a/backend/src/test/java/com/google/sps/UserDatastoreTest.java
+++ b/backend/src/test/java/com/google/sps/UserDatastoreTest.java
@@ -24,6 +24,7 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.sps.data.MatchPreference;
 import com.google.sps.data.User;
 import com.google.sps.datastore.UserDatastore;
 import org.junit.After;
@@ -37,6 +38,10 @@ public final class UserDatastoreTest {
 
   // Default values
   private static final long ID_DEFAULT = 0;
+  private static final int DURATION_DEFAULT = 30;
+  private static final String ROLE_DEFAULT = "Software engineer";
+  private static final String PRODUCT_AREA_DEFAULT = "Ads";
+  private static final MatchPreference MATCH_PREFERENCE_DEFAULT = MatchPreference.SIMILAR;
 
   // Some usernames
   private static final String PERSON_A = "Person A";
@@ -45,6 +50,10 @@ public final class UserDatastoreTest {
   // Datastore Key/Property constants
   private static final String KIND_USER = "User";
   private static final String PROPERTY_USERNAME = "username";
+  private static final String PROPERTY_DURATION = "duration";
+  private static final String PROPERTY_ROLE = "role";
+  private static final String PROPERTY_PRODUCT_AREA = "productArea";
+  private static final String PROPERTY_MATCH_PREFERENCE = "matchPreference";
 
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
@@ -65,13 +74,27 @@ public final class UserDatastoreTest {
     // Add one user to datastore
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
-    User userA = new User(ID_DEFAULT, PERSON_A);
+    User user =
+        new User(
+            PERSON_A,
+            DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT);
 
-    userDatastore.addUser(userA);
+    userDatastore.addUser(user);
 
-    Key keyA = KeyFactory.createKey(KIND_USER, PERSON_A);
-    Entity entityA = datastore.get(keyA);
-    assertThat((String) entityA.getProperty(PROPERTY_USERNAME)).isEqualTo(PERSON_A);
+    Key key = KeyFactory.createKey(KIND_USER, PERSON_A);
+    Entity entity = datastore.get(key);
+    assertThat((String) entity.getProperty(PROPERTY_USERNAME)).isEqualTo(PERSON_A);
+    assertThat(((Long) entity.getProperty(PROPERTY_DURATION)).intValue())
+        .isEqualTo(DURATION_DEFAULT);
+    assertThat((String) entity.getProperty(PROPERTY_ROLE)).isEqualTo(ROLE_DEFAULT);
+    assertThat((String) entity.getProperty(PROPERTY_PRODUCT_AREA)).isEqualTo(PRODUCT_AREA_DEFAULT);
+    assertThat(
+            MatchPreference.forIntValue(
+                ((Long) entity.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()))
+        .isEqualTo(MATCH_PREFERENCE_DEFAULT);
   }
 
   @Test
@@ -79,8 +102,20 @@ public final class UserDatastoreTest {
     // Add two users to datastore
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
-    User userA = new User(ID_DEFAULT, PERSON_A);
-    User userB = new User(ID_DEFAULT, PERSON_B);
+    User userA =
+        new User(
+            PERSON_A,
+            DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT);
+    User userB =
+        new User(
+            PERSON_B,
+            DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT);
 
     userDatastore.addUser(userA);
     userDatastore.addUser(userB);
@@ -90,7 +125,23 @@ public final class UserDatastoreTest {
     Entity entityA = datastore.get(keyA);
     Entity entityB = datastore.get(keyB);
     assertThat((String) entityA.getProperty(PROPERTY_USERNAME)).isEqualTo(PERSON_A);
+    assertThat(((Long) entityA.getProperty(PROPERTY_DURATION)).intValue())
+        .isEqualTo(DURATION_DEFAULT);
+    assertThat((String) entityA.getProperty(PROPERTY_ROLE)).isEqualTo(ROLE_DEFAULT);
+    assertThat((String) entityA.getProperty(PROPERTY_PRODUCT_AREA)).isEqualTo(PRODUCT_AREA_DEFAULT);
+    assertThat(
+            MatchPreference.forIntValue(
+                ((Long) entityA.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()))
+        .isEqualTo(MATCH_PREFERENCE_DEFAULT);
     assertThat((String) entityB.getProperty(PROPERTY_USERNAME)).isEqualTo(PERSON_B);
+    assertThat(((Long) entityB.getProperty(PROPERTY_DURATION)).intValue())
+        .isEqualTo(DURATION_DEFAULT);
+    assertThat((String) entityB.getProperty(PROPERTY_ROLE)).isEqualTo(ROLE_DEFAULT);
+    assertThat((String) entityB.getProperty(PROPERTY_PRODUCT_AREA)).isEqualTo(PRODUCT_AREA_DEFAULT);
+    assertThat(
+            MatchPreference.forIntValue(
+                ((Long) entityB.getProperty(PROPERTY_MATCH_PREFERENCE)).intValue()))
+        .isEqualTo(MATCH_PREFERENCE_DEFAULT);
   }
 
   @Test
@@ -98,9 +149,15 @@ public final class UserDatastoreTest {
     // Add one user to datastore, return user from username
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     UserDatastore userDatastore = new UserDatastore(datastore);
-    User userA = new User(ID_DEFAULT, PERSON_A);
+    User user =
+        new User(
+            PERSON_A,
+            DURATION_DEFAULT,
+            ROLE_DEFAULT,
+            PRODUCT_AREA_DEFAULT,
+            MATCH_PREFERENCE_DEFAULT);
 
-    userDatastore.addUser(userA);
+    userDatastore.addUser(user);
 
     assertThat(userDatastore.getUserFromUsername(PERSON_A).getUsername()).isEqualTo(PERSON_A);
   }


### PR DESCRIPTION
Files changed:
- Participant/ParticipantDatastore/ParticipantDatastoreTest: add personal fields and test
- User/UserDatastore/UserDatastoreTest: add personal fields and test
- FindMatchQuery/FindMatchQueryTest: include personal fields/match preference logic to match query and test
- AddParticipantServlet: use form input fields, add user if opted to save preference
- MatchPreference: enum for preference of being matched with similar, any, or different Googler