### PR TITLE
Add jest-html tool to preview snapshot files in browser

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,8 @@
     "local": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "jest-html": "jest-html"
   },
   "engines": {
     "node": "10.x.x"
@@ -52,6 +53,10 @@
   },
   "devDependencies": {
     "eslint-config-google": "^0.14.0",
-    "eslint-plugin-react": "^7.20.3"
+    "eslint-plugin-react": "^7.20.3",
+    "jest-html": "^1.5.0"
+  },
+  "jest": {
+    "snapshotSerializers": ["jest-html"]
   }
 }

--- a/frontend/src/__snapshots__/App.test.js.snap
+++ b/frontend/src/__snapshots__/App.test.js.snap
@@ -733,4 +733,426 @@ exports[`App should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div class="makeStyles-root-3">
+    <header class="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation4">
+      <div class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters">
+        <h6 class="MuiTypography-root makeStyles-title-5 MuiTypography-h6">
+          Ad-lib
+        </h6>
+        <div>
+          <button
+            aria-controls="help-appbar"
+            aria-label="help-icon"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+            type="button"
+          >
+            <span class="MuiIconButton-label">
+              <svg
+                aria-hidden
+                class="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </header>
+  </div>
+  <div class="makeStyles-centerHorizontal-1">
+    <div>
+      <div class="MuiPaper-root MuiCard-root makeStyles-content-6 MuiPaper-elevation1 MuiPaper-rounded">
+        <div class="MuiCardContent-root">
+          <h3>
+            Meet fellow Googlers 
+            <em>
+              now
+            </em>
+            !
+          </h3>
+          <p>
+            Miss bumping into new faces at the office? Want an easy, fun, spontaneous way of meeting Googlers virtually? Now you can!
+          </p>
+          <p>
+            Ad-lib matches you with a fellow Googler in the queue, notifies you through email when you’ve been matched, and adds an event to your Calendar with a Meet link for you to join immediately! It also provides a starter question to get the conversation flowing!
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="MuiPaper-root MuiCard-root makeStyles-content-2 MuiPaper-elevation1 MuiPaper-rounded">
+      <div>
+        <div class="makeStyles-heading-10">
+          <h3>
+            Choose your time preferences
+          </h3>
+        </div>
+        <div class="makeStyles-section-9">
+          <div class="makeStyles-flexStartDiv-7">
+            <p>
+              I am free until...
+            </p>
+            <div style="width:180px;">
+              <div class="MuiFormControl-root MuiTextField-root">
+                <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd">
+                  <input
+                    class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+                    id="time-field"
+                    type="text"
+                    value="12:00 AM"
+                  >
+                  <div class="MuiInputAdornment-root MuiInputAdornment-positionEnd">
+                    <button
+                      aria-label="time-field"
+                      class="MuiButtonBase-root MuiIconButton-root"
+                      type="button"
+                    >
+                      <span class="MuiIconButton-label">
+                        <svg
+                          aria-hidden
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          >
+                          </path>
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                
+              </div>
+            </div>
+          </div>
+          <div class="makeStyles-flexStartDiv-7">
+            <p>
+              I want to talk for...
+            </p>
+            <div>
+              <div
+                class="MuiFormControl-root"
+                style="width:180px;"
+              >
+                <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="duration"
+                    aria-labelledby="duration-input"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                    id="duration-input"
+                    role="button"
+                  >
+                    15 minutes
+                  </div>
+                  <input
+                    aria-hidden
+                    class="MuiSelect-nativeInput"
+                    name="duration"
+                  >
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root MuiSelect-icon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M7 10l5 5 5-5z"></path>
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="makeStyles-heading-10">
+          <h3>
+            Choose your match preferences
+          </h3>
+        </div>
+        <div class="makeStyles-section-9">
+          <div class="makeStyles-flexStartDiv-7">
+            <div>
+              <div
+                class="MuiFormControl-root"
+                style="width:180px;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  id="role"
+                >
+                  Role
+                </label>
+                <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="role"
+                    aria-labelledby="role-input"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                    id="role-input"
+                    role="button"
+                  >
+                    <span></span>
+                  </div>
+                  <input
+                    aria-hidden
+                    class="MuiSelect-nativeInput"
+                    name="role"
+                  >
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root MuiSelect-icon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M7 10l5 5 5-5z"></path>
+                  </svg>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="MuiFormControl-root"
+                style="width:180px;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  id="productArea"
+                >
+                  Product Area
+                </label>
+                <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="productArea"
+                    aria-labelledby="productArea-input"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                    id="productArea-input"
+                    role="button"
+                  >
+                    <span></span>
+                  </div>
+                  <input
+                    aria-hidden
+                    class="MuiSelect-nativeInput"
+                    name="productArea"
+                  >
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root MuiSelect-icon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M7 10l5 5 5-5z"></path>
+                  </svg>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="MuiFormControl-root"
+                style="width:180px;"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  id="interests"
+                >
+                  Interests
+                </label>
+                <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+                  <div
+                    aria-haspopup="listbox"
+                    aria-label="interests"
+                    aria-labelledby="interests"
+                    class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                    id="interests"
+                    role="button"
+                  >
+                    <span></span>
+                  </div>
+                  <input
+                    aria-hidden
+                    class="MuiSelect-nativeInput"
+                    name="interests"
+                    value=""
+                  >
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root MuiSelect-icon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M7 10l5 5 5-5z"></path>
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="makeStyles-padding-11">
+            <fieldset class="MuiFormControl-root">
+              <div
+                aria-label="matchPreference"
+                class="MuiFormGroup-root MuiFormGroup-row"
+                defaultValue="any"
+                role="radiogroup"
+              >
+                <label class="MuiFormControlLabel-root Mui-disabled">
+                  <span
+                    aria-disabled
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-15 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-disabled-17 Mui-disabled MuiIconButton-colorPrimary Mui-disabled Mui-disabled"
+                  >
+                    <span class="MuiIconButton-label">
+                      <input
+                        class="PrivateSwitchBase-input-18"
+                        disabled
+                        name="matchPreference"
+                        type="radio"
+                        value="similar"
+                      >
+                      <div class="PrivateRadioButtonIcon-root-19">
+                        <svg
+                          aria-hidden
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                        </svg>
+                        <svg
+                          aria-hidden
+                          class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-20"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+                        </svg>
+                      </div>
+                    </span>
+                  </span>
+                  <span class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1">
+                    Similar Googler
+                  </span>
+                </label>
+                <label class="MuiFormControlLabel-root">
+                  <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-15 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-checked-16 Mui-checked MuiIconButton-colorPrimary">
+                    <span class="MuiIconButton-label">
+                      <input
+                        checked
+                        class="PrivateSwitchBase-input-18"
+                        name="matchPreference"
+                        type="radio"
+                        value="any"
+                      >
+                      <div class="PrivateRadioButtonIcon-root-19 PrivateRadioButtonIcon-checked-21">
+                        <svg
+                          aria-hidden
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                        </svg>
+                        <svg
+                          aria-hidden
+                          class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-20"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+                        </svg>
+                      </div>
+                    </span>
+                  </span>
+                  <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+                    Any Googler
+                  </span>
+                </label>
+                <label class="MuiFormControlLabel-root Mui-disabled">
+                  <span
+                    aria-disabled
+                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-15 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-disabled-17 Mui-disabled MuiIconButton-colorPrimary Mui-disabled Mui-disabled"
+                  >
+                    <span class="MuiIconButton-label">
+                      <input
+                        class="PrivateSwitchBase-input-18"
+                        disabled
+                        name="matchPreference"
+                        type="radio"
+                        value="different"
+                      >
+                      <div class="PrivateRadioButtonIcon-root-19">
+                        <svg
+                          aria-hidden
+                          class="MuiSvgIcon-root"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                        </svg>
+                        <svg
+                          aria-hidden
+                          class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-20"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+                        </svg>
+                      </div>
+                    </span>
+                  </span>
+                  <span class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1">
+                    Different Googler
+                  </span>
+                </label>
+              </div>
+              <p class="MuiFormHelperText-root">
+                You must select at least one personal preference field to select a match preference 
+              </p>
+            </fieldset>
+          </div>
+        </div>
+        <div class="makeStyles-flexEndDiv-8">
+          <label class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementStart">
+            <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-15 MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-checked-16 Mui-checked MuiIconButton-colorPrimary">
+              <span class="MuiIconButton-label">
+                <input
+                  class="PrivateSwitchBase-input-18"
+                  defaultChecked
+                  name="checkbox"
+                  type="checkbox"
+                >
+                <svg
+                  aria-hidden
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path>
+                </svg>
+              </span>
+            </span>
+            <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+              Save my preferences for later
+            </span>
+          </label>
+          <div class="makeStyles-flexEndDiv-8">
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+              type="button"
+            >
+              <span class="MuiButton-label">
+                Match me!
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/DurationDropdown.test.js.snap
+++ b/frontend/src/components/__snapshots__/DurationDropdown.test.js.snap
@@ -52,4 +52,37 @@ exports[`Duration Dropdown should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div
+    class="MuiFormControl-root"
+    style="width:180px;"
+  >
+    <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+      <div
+        aria-haspopup="listbox"
+        aria-label="duration"
+        aria-labelledby="duration-input"
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+        id="duration-input"
+        role="button"
+      >
+        15 minutes
+      </div>
+      <input
+        aria-hidden
+        class="MuiSelect-nativeInput"
+        name="duration"
+      >
+      <svg
+        aria-hidden
+        class="MuiSvgIcon-root MuiSelect-icon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path d="M7 10l5 5 5-5z"></path>
+      </svg>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/ErrorPage.test.js.snap
+++ b/frontend/src/components/__snapshots__/ErrorPage.test.js.snap
@@ -22,10 +22,10 @@ exports[`Error Page should render correctly 1`] = `
   <div class="MuiPaper-root MuiCard-root makeStyles-content-1 MuiPaper-elevation1 MuiPaper-rounded">
     <div class="MuiCardContent-root">
       <h3>
-        Oops, something went wrong
+        Oops, something went wrong!
       </h3>
       <p>
-        We encourage you to please try again later!
+        We apologize for the inconvenience. Please try again later!
       </p>
     </div>
   </div>

--- a/frontend/src/components/__snapshots__/ErrorPage.test.js.snap
+++ b/frontend/src/components/__snapshots__/ErrorPage.test.js.snap
@@ -17,4 +17,17 @@ exports[`Error Page should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div class="MuiPaper-root MuiCard-root makeStyles-content-1 MuiPaper-elevation1 MuiPaper-rounded">
+    <div class="MuiCardContent-root">
+      <h3>
+        Oops, something went wrong
+      </h3>
+      <p>
+        We encourage you to please try again later!
+      </p>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/Form.test.js.snap
+++ b/frontend/src/components/__snapshots__/Form.test.js.snap
@@ -647,4 +647,373 @@ exports[`Form should render correctly in varying times and timezones 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div class="makeStyles-heading-4">
+    <h3>
+      Choose your time preferences
+    </h3>
+  </div>
+  <div class="makeStyles-section-3">
+    <div class="makeStyles-flexStartDiv-1">
+      <p>
+        I am free until...
+      </p>
+      <div style="width:180px;">
+        <div class="MuiFormControl-root MuiTextField-root">
+          <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd">
+            <input
+              class="MuiInputBase-input MuiInput-input MuiInputBase-inputAdornedEnd"
+              id="time-field"
+              type="text"
+              value="12:00 AM"
+            >
+            <div class="MuiInputAdornment-root MuiInputAdornment-positionEnd">
+              <button
+                aria-label="time-field"
+                class="MuiButtonBase-root MuiIconButton-root"
+                type="button"
+              >
+                <span class="MuiIconButton-label">
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M17 12h-5v5h5v-5zM16 1v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-1V1h-2zm3 18H5V8h14v11z"></path>
+                    <path
+                      d="M0 0h24v24H0z"
+                      fill="none"
+                    >
+                    </path>
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+    </div>
+    <div class="makeStyles-flexStartDiv-1">
+      <p>
+        I want to talk for...
+      </p>
+      <div>
+        <div
+          class="MuiFormControl-root"
+          style="width:180px;"
+        >
+          <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+            <div
+              aria-haspopup="listbox"
+              aria-label="duration"
+              aria-labelledby="duration-input"
+              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+              id="duration-input"
+              role="button"
+            >
+              15 minutes
+            </div>
+            <input
+              aria-hidden
+              class="MuiSelect-nativeInput"
+              name="duration"
+            >
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root MuiSelect-icon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M7 10l5 5 5-5z"></path>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="makeStyles-heading-4">
+    <h3>
+      Choose your match preferences
+    </h3>
+  </div>
+  <div class="makeStyles-section-3">
+    <div class="makeStyles-flexStartDiv-1">
+      <div>
+        <div
+          class="MuiFormControl-root"
+          style="width:180px;"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+            id="role"
+          >
+            Role
+          </label>
+          <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+            <div
+              aria-haspopup="listbox"
+              aria-label="role"
+              aria-labelledby="role-input"
+              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+              id="role-input"
+              role="button"
+            >
+              <span></span>
+            </div>
+            <input
+              aria-hidden
+              class="MuiSelect-nativeInput"
+              name="role"
+            >
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root MuiSelect-icon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M7 10l5 5 5-5z"></path>
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          class="MuiFormControl-root"
+          style="width:180px;"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+            id="productArea"
+          >
+            Product Area
+          </label>
+          <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+            <div
+              aria-haspopup="listbox"
+              aria-label="productArea"
+              aria-labelledby="productArea-input"
+              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+              id="productArea-input"
+              role="button"
+            >
+              <span></span>
+            </div>
+            <input
+              aria-hidden
+              class="MuiSelect-nativeInput"
+              name="productArea"
+            >
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root MuiSelect-icon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M7 10l5 5 5-5z"></path>
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          class="MuiFormControl-root"
+          style="width:180px;"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+            id="interests"
+          >
+            Interests
+          </label>
+          <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+            <div
+              aria-haspopup="listbox"
+              aria-label="interests"
+              aria-labelledby="interests"
+              class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+              id="interests"
+              role="button"
+            >
+              <span></span>
+            </div>
+            <input
+              aria-hidden
+              class="MuiSelect-nativeInput"
+              name="interests"
+              value=""
+            >
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root MuiSelect-icon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M7 10l5 5 5-5z"></path>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="makeStyles-padding-5">
+      <fieldset class="MuiFormControl-root">
+        <div
+          aria-label="matchPreference"
+          class="MuiFormGroup-root MuiFormGroup-row"
+          defaultValue="any"
+          role="radiogroup"
+        >
+          <label class="MuiFormControlLabel-root Mui-disabled">
+            <span
+              aria-disabled
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-9 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-disabled-11 Mui-disabled MuiIconButton-colorPrimary Mui-disabled Mui-disabled"
+            >
+              <span class="MuiIconButton-label">
+                <input
+                  class="PrivateSwitchBase-input-12"
+                  disabled
+                  name="matchPreference"
+                  type="radio"
+                  value="similar"
+                >
+                <div class="PrivateRadioButtonIcon-root-13">
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                  </svg>
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-14"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+                  </svg>
+                </div>
+              </span>
+            </span>
+            <span class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1">
+              Similar Googler
+            </span>
+          </label>
+          <label class="MuiFormControlLabel-root">
+            <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-9 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-checked-10 Mui-checked MuiIconButton-colorPrimary">
+              <span class="MuiIconButton-label">
+                <input
+                  checked
+                  class="PrivateSwitchBase-input-12"
+                  name="matchPreference"
+                  type="radio"
+                  value="any"
+                >
+                <div class="PrivateRadioButtonIcon-root-13 PrivateRadioButtonIcon-checked-15">
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                  </svg>
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-14"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+                  </svg>
+                </div>
+              </span>
+            </span>
+            <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+              Any Googler
+            </span>
+          </label>
+          <label class="MuiFormControlLabel-root Mui-disabled">
+            <span
+              aria-disabled
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-9 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-disabled-11 Mui-disabled MuiIconButton-colorPrimary Mui-disabled Mui-disabled"
+            >
+              <span class="MuiIconButton-label">
+                <input
+                  class="PrivateSwitchBase-input-12"
+                  disabled
+                  name="matchPreference"
+                  type="radio"
+                  value="different"
+                >
+                <div class="PrivateRadioButtonIcon-root-13">
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                  </svg>
+                  <svg
+                    aria-hidden
+                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-14"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+                  </svg>
+                </div>
+              </span>
+            </span>
+            <span class="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1">
+              Different Googler
+            </span>
+          </label>
+        </div>
+        <p class="MuiFormHelperText-root">
+          You must select at least one personal preference field to select a match preference 
+        </p>
+      </fieldset>
+    </div>
+  </div>
+  <div class="makeStyles-flexEndDiv-2">
+    <label class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementStart">
+      <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-9 MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-checked-10 Mui-checked MuiIconButton-colorPrimary">
+        <span class="MuiIconButton-label">
+          <input
+            class="PrivateSwitchBase-input-12"
+            defaultChecked
+            name="checkbox"
+            type="checkbox"
+          >
+          <svg
+            aria-hidden
+            class="MuiSvgIcon-root"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path>
+          </svg>
+        </span>
+      </span>
+      <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+        Save my preferences for later
+      </span>
+    </label>
+    <div class="makeStyles-flexEndDiv-2">
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+        type="button"
+      >
+        <span class="MuiButton-label">
+          Match me!
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/FormContent.test.js.snap
+++ b/frontend/src/components/__snapshots__/FormContent.test.js.snap
@@ -24,4 +24,24 @@ exports[`Form Content should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div class="MuiPaper-root MuiCard-root makeStyles-content-1 MuiPaper-elevation1 MuiPaper-rounded">
+    <div class="MuiCardContent-root">
+      <h3>
+        Meet fellow Googlers 
+        <em>
+          now
+        </em>
+        !
+      </h3>
+      <p>
+        Miss bumping into new faces at the office? Want an easy, fun, spontaneous way of meeting Googlers virtually? Now you can!
+      </p>
+      <p>
+        Ad-lib matches you with a fellow Googler in the queue, notifies you through email when you’ve been matched, and adds an event to your Calendar with a Meet link for you to join immediately! It also provides a starter question to get the conversation flowing!
+      </p>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/InterestsDropdown.test.js.snap
+++ b/frontend/src/components/__snapshots__/InterestsDropdown.test.js.snap
@@ -65,4 +65,44 @@ exports[`Interests Dropdown should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div
+    class="MuiFormControl-root"
+    style="width:180px;"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      id="interests"
+    >
+      Interests
+    </label>
+    <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+      <div
+        aria-haspopup="listbox"
+        aria-label="interests"
+        aria-labelledby="interests"
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+        id="interests"
+        role="button"
+      >
+        <span></span>
+      </div>
+      <input
+        aria-hidden
+        class="MuiSelect-nativeInput"
+        name="interests"
+        value=""
+      >
+      <svg
+        aria-hidden
+        class="MuiSvgIcon-root MuiSelect-icon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path d="M7 10l5 5 5-5z"></path>
+      </svg>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/LoadingPage.test.js.snap
+++ b/frontend/src/components/__snapshots__/LoadingPage.test.js.snap
@@ -59,4 +59,42 @@ exports[`Loading Page should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div class="MuiPaper-root MuiCard-root makeStyles-content-1 MuiPaper-elevation1 MuiPaper-rounded">
+    <div class="MuiCardContent-root">
+      <h3>
+        Finding you a match...
+      </h3>
+      <p>
+        <em>
+          This part may take some time as we wait for more Googlers to enter the queue.
+        </em>
+      </p>
+      <p>
+        While you’re waiting on this page, you can continue working, learn about 
+        <a href="https://guidetoallyship.com/">
+          Allyship
+        </a>
+        , or even make a smoothie! We will send you an 
+        <b>
+          email 
+        </b>
+        and 
+        <b>
+          Calendar invite
+        </b>
+         as soon as we find you a match!
+      </p>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+        type="button"
+      >
+        <span class="MuiButton-label">
+          Exit Queue
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/MatchPage.test.js.snap
+++ b/frontend/src/components/__snapshots__/MatchPage.test.js.snap
@@ -20,4 +20,20 @@ exports[`Match Page should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div class="MuiPaper-root MuiCard-root makeStyles-content-1 MuiPaper-elevation1 MuiPaper-rounded">
+    <div class="MuiCardContent-root">
+      <h3>
+        We found you a match!
+      </h3>
+      <p>
+        This Googler is so excited to meet you.
+      </p>
+      <p>
+        Please check your Calendar to find the event and Meet link and join to meet your new friend
+      </p>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/MatchPage.test.js.snap
+++ b/frontend/src/components/__snapshots__/MatchPage.test.js.snap
@@ -28,10 +28,10 @@ exports[`Match Page should render correctly 1`] = `
         We found you a match!
       </h3>
       <p>
-        This Googler is so excited to meet you.
+         is so excited to meet you!
       </p>
       <p>
-        Please check your Calendar to find the event and Meet link and join to meet your new friend
+        Please check your Calendar to find the event and Meet link and join to meet your new friend.
       </p>
     </div>
   </div>

--- a/frontend/src/components/__snapshots__/MatchPreference.test.js.snap
+++ b/frontend/src/components/__snapshots__/MatchPreference.test.js.snap
@@ -206,4 +206,117 @@ exports[`Match Preferences Radio Group should render correctly 1`] = `
     You must select at least one personal preference field to select a match preference 
   </p>
 </fieldset>
+------------HTML PREVIEW---------------
+<fieldset class="MuiFormControl-root">
+  <div
+    aria-label="matchPreference"
+    class="MuiFormGroup-root MuiFormGroup-row"
+    defaultValue="any"
+    role="radiogroup"
+  >
+    <label class="MuiFormControlLabel-root">
+      <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary">
+        <span class="MuiIconButton-label">
+          <input
+            class="PrivateSwitchBase-input-4"
+            name="matchPreference"
+            type="radio"
+            value="similar"
+          >
+          <div class="PrivateRadioButtonIcon-root-5">
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+            </svg>
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+            </svg>
+          </div>
+        </span>
+      </span>
+      <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+        Similar Googler
+      </span>
+    </label>
+    <label class="MuiFormControlLabel-root">
+      <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-checked-2 Mui-checked MuiIconButton-colorPrimary">
+        <span class="MuiIconButton-label">
+          <input
+            checked
+            class="PrivateSwitchBase-input-4"
+            name="matchPreference"
+            type="radio"
+            value="any"
+          >
+          <div class="PrivateRadioButtonIcon-root-5 PrivateRadioButtonIcon-checked-7">
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+            </svg>
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+            </svg>
+          </div>
+        </span>
+      </span>
+      <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+        Any Googler
+      </span>
+    </label>
+    <label class="MuiFormControlLabel-root">
+      <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary">
+        <span class="MuiIconButton-label">
+          <input
+            class="PrivateSwitchBase-input-4"
+            name="matchPreference"
+            type="radio"
+            value="different"
+          >
+          <div class="PrivateRadioButtonIcon-root-5">
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+            </svg>
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"></path>
+            </svg>
+          </div>
+        </span>
+      </span>
+      <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+        Different Googler
+      </span>
+    </label>
+  </div>
+  <p class="MuiFormHelperText-root">
+    You must select at least one personal preference field to select a match preference 
+  </p>
+</fieldset>
 `;

--- a/frontend/src/components/__snapshots__/MenuBar.test.js.snap
+++ b/frontend/src/components/__snapshots__/MenuBar.test.js.snap
@@ -54,4 +54,33 @@ exports[`Menu Bar should render correctly 1`] = `
     </div>
   </header>
 </div>
+------------HTML PREVIEW---------------
+<div class="makeStyles-root-1">
+  <header class="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary MuiPaper-elevation4">
+    <div class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters">
+      <h6 class="MuiTypography-root makeStyles-title-3 MuiTypography-h6">
+        Ad-lib
+      </h6>
+      <div>
+        <button
+          aria-controls="help-appbar"
+          aria-label="help-icon"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+          type="button"
+        >
+          <span class="MuiIconButton-label">
+            <svg
+              aria-hidden
+              class="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  </header>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/NoMatchPage.test.js.snap
+++ b/frontend/src/components/__snapshots__/NoMatchPage.test.js.snap
@@ -24,10 +24,12 @@ exports[`NoMatch Page should render correctly 1`] = `
   <div class="MuiPaper-root MuiCard-root makeStyles-content-1 MuiPaper-elevation1 MuiPaper-rounded">
     <div class="MuiCardContent-root">
       <h3>
-        We could not find you a match!
+        Sorry, we could not find you a match :(
       </h3>
       <p>
-        It looks like you are only free until 11:45am, and we could not find you a match to meet or 30 minutes before then. Please try again later, and happy working!
+        It looks like you are only free until
+        , and we could not find you a match to meet for 
+         minutes before then. Please try again later, and happy working!
       </p>
     </div>
   </div>

--- a/frontend/src/components/__snapshots__/NoMatchPage.test.js.snap
+++ b/frontend/src/components/__snapshots__/NoMatchPage.test.js.snap
@@ -17,4 +17,17 @@ exports[`NoMatch Page should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div class="MuiPaper-root MuiCard-root makeStyles-content-1 MuiPaper-elevation1 MuiPaper-rounded">
+    <div class="MuiCardContent-root">
+      <h3>
+        We could not find you a match!
+      </h3>
+      <p>
+        It looks like you are only free until 11:45am, and we could not find you a match to meet or 30 minutes before then. Please try again later, and happy working!
+      </p>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/PreferencesCheckbox.test.js.snap
+++ b/frontend/src/components/__snapshots__/PreferencesCheckbox.test.js.snap
@@ -49,4 +49,28 @@ exports[`Preferences Checkbox should render correctly 1`] = `
     Save my preferences for later
   </span>
 </label>
+------------HTML PREVIEW---------------
+<label class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementStart">
+  <span class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-checked-2 Mui-checked MuiIconButton-colorPrimary">
+    <span class="MuiIconButton-label">
+      <input
+        class="PrivateSwitchBase-input-4"
+        defaultChecked
+        name="checkbox"
+        type="checkbox"
+      >
+      <svg
+        aria-hidden
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path>
+      </svg>
+    </span>
+  </span>
+  <span class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1">
+    Save my preferences for later
+  </span>
+</label>
 `;

--- a/frontend/src/components/__snapshots__/ProductAreaDropdown.test.js.snap
+++ b/frontend/src/components/__snapshots__/ProductAreaDropdown.test.js.snap
@@ -64,4 +64,43 @@ exports[`Product Area Dropdown should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div
+    class="MuiFormControl-root"
+    style="width:180px;"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      id="productArea"
+    >
+      Product Area
+    </label>
+    <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+      <div
+        aria-haspopup="listbox"
+        aria-label="productArea"
+        aria-labelledby="productArea-input"
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+        id="productArea-input"
+        role="button"
+      >
+        <span></span>
+      </div>
+      <input
+        aria-hidden
+        class="MuiSelect-nativeInput"
+        name="productArea"
+      >
+      <svg
+        aria-hidden
+        class="MuiSvgIcon-root MuiSelect-icon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path d="M7 10l5 5 5-5z"></path>
+      </svg>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/src/components/__snapshots__/RoleDropdown.test.js.snap
+++ b/frontend/src/components/__snapshots__/RoleDropdown.test.js.snap
@@ -64,4 +64,43 @@ exports[`Role Dropdown should render correctly 1`] = `
     </div>
   </div>
 </div>
+------------HTML PREVIEW---------------
+<div>
+  <div
+    class="MuiFormControl-root"
+    style="width:180px;"
+  >
+    <label
+      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      id="role"
+    >
+      Role
+    </label>
+    <div class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl">
+      <div
+        aria-haspopup="listbox"
+        aria-label="role"
+        aria-labelledby="role-input"
+        class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+        id="role-input"
+        role="button"
+      >
+        <span></span>
+      </div>
+      <input
+        aria-hidden
+        class="MuiSelect-nativeInput"
+        name="role"
+      >
+      <svg
+        aria-hidden
+        class="MuiSvgIcon-root MuiSelect-icon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path d="M7 10l5 5 5-5z"></path>
+      </svg>
+    </div>
+  </div>
+</div>
 `;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1990,6 +1990,11 @@ adjust-sourcemap-loader@2.0.0:
     object-path "0.11.4"
     regex-parser "2.2.10"
 
+after@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
+  integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
+
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
@@ -2262,6 +2267,11 @@ array.prototype.flatmap@^1.2.3:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
 
+arraybuffer.slice@~0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
+  integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
+
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -2501,6 +2511,15 @@ babel-plugin-transform-react-remove-prop-types@0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
+babel-polyfill@6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"
@@ -2543,15 +2562,30 @@ babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
+backo2@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-arraybuffer@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
+  integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
+
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
+base64id@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
+  integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
 base@^0.11.1:
   version "0.11.2"
@@ -2578,6 +2612,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+better-assert@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
+  integrity sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
+  dependencies:
+    callsite "1.0.0"
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2600,6 +2641,11 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+blob@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
+  integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
+
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -2615,7 +2661,7 @@ bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
   integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.18.3:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -2915,6 +2961,11 @@ caller-path@^2.0.0:
   dependencies:
     caller-callsite "^2.0.0"
 
+callsite@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
@@ -2980,6 +3031,17 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chalk@1.x, chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
 chalk@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
@@ -2997,17 +3059,6 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
 
 chalk@^3.0.0:
   version "3.0.0"
@@ -3042,7 +3093,7 @@ cheerio@^1.0.0-rc.3:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@^2.1.8:
+chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -3275,7 +3326,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.19.0, commander@^2.20.0:
+commander@^2.11.0, commander@^2.17.1, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3295,10 +3346,25 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-emitter@^1.2.1:
+component-bind@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
+  integrity sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=
+
+component-emitter@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+
+component-emitter@^1.2.1, component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+component-inherit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
+  integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
 
 compose-function@3.0.3:
   version "3.0.3"
@@ -3414,6 +3480,11 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
 cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
@@ -3449,7 +3520,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -3842,7 +3913,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0:
+debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -3856,7 +3927,7 @@ debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -4239,6 +4310,46 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+engine.io-client@~3.4.0:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.4.3.tgz#192d09865403e3097e3575ebfeb3861c4d01a66c"
+  integrity sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==
+  dependencies:
+    component-emitter "~1.3.0"
+    component-inherit "0.0.3"
+    debug "~4.1.0"
+    engine.io-parser "~2.2.0"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    ws "~6.1.0"
+    xmlhttprequest-ssl "~1.5.4"
+    yeast "0.1.2"
+
+engine.io-parser@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.0.tgz#312c4894f57d52a02b420868da7b5c1c84af80ed"
+  integrity sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==
+  dependencies:
+    after "0.8.2"
+    arraybuffer.slice "~0.0.7"
+    base64-arraybuffer "0.1.5"
+    blob "0.0.5"
+    has-binary2 "~1.0.2"
+
+engine.io@~3.4.0:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.4.2.tgz#8fc84ee00388e3e228645e0a7d3dfaeed5bd122c"
+  integrity sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "0.3.1"
+    debug "~4.1.0"
+    engine.io-parser "~2.2.0"
+    ws "^7.1.2"
+
 enhanced-resolve@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.2.0.tgz#5d43bda4a0fd447cb0ebbe71bef8deff8805ad0d"
@@ -4403,7 +4514,7 @@ escalade@^3.0.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.1.tgz#52568a77443f6927cd0ab9c73129137533c965ed"
   integrity sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==
 
-escape-html@~1.0.3:
+escape-html@1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -4774,7 +4885,7 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
-express@^4.17.1:
+express@^4.16.3, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -5358,7 +5469,7 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-globby@8.0.2:
+globby@8.0.2, globby@^8.0.1:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
   integrity sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==
@@ -5429,6 +5540,18 @@ has-ansi@^2.0.0:
   integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
+
+has-binary2@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
+  integrity sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==
+  dependencies:
+    isarray "2.0.1"
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+  integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -5795,6 +5918,11 @@ indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
+
+indexof@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
 infer-owner@^1.0.3, infer-owner@^1.0.4:
   version "1.0.4"
@@ -6244,6 +6372,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+isarray@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
+  integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -6448,6 +6581,27 @@ jest-haste-map@^24.9.0:
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^1.2.7"
+
+jest-html@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jest-html/-/jest-html-1.5.0.tgz#e9e0809f1f2ad44bd2cb515c35ceb3776d299cab"
+  integrity sha512-Q2NdWPJSOCN9El0u1lxv/tEo3WwpVgCVk8Hi5qw2a7uHzxil8sqaSXlXc1CACxh3DWnhnoixA9IgxkqeNFQ4Dw==
+  dependencies:
+    babel-polyfill "6.26.0"
+    body-parser "^1.18.3"
+    chokidar "^2.0.4"
+    commander "^2.17.1"
+    escape-html "1.0.3"
+    express "^4.16.3"
+    globby "^8.0.1"
+    lodash.debounce "4.0.8"
+    opn "^5.3.0"
+    pretty-format "^23.5.0"
+    socket.io "^2.1.1"
+    storyboard "^3.1.4"
+    storyboard-preset-console "^3.1.4"
+    timm "^1.6.1"
+    whatwg-fetch "^2.0.4"
 
 jest-jasmine2@^24.9.0:
   version "24.9.0"
@@ -7121,6 +7275,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.debounce@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -7166,7 +7325,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -7766,6 +7925,11 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-component@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
+  integrity sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=
+
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -7903,7 +8067,7 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-opn@^5.5.0:
+opn@^5.3.0, opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
@@ -8130,6 +8294,20 @@ parse5@^3.0.1:
   dependencies:
     "@types/node" "*"
 
+parseqs@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
+  integrity sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=
+  dependencies:
+    better-assert "~1.0.0"
+
+parseuri@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
+  integrity sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=
+  dependencies:
+    better-assert "~1.0.0"
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -8318,6 +8496,11 @@ pkg-up@3.1.0, pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+platform@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
+  integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
 pn@^1.1.0:
   version "1.1.0"
@@ -9034,6 +9217,14 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
+pretty-format@^23.5.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
+  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 pretty-format@^24.0.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
@@ -9547,6 +9738,11 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
   integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
 
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
+
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
@@ -9994,7 +10190,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -10265,6 +10461,61 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+socket.io-adapter@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz#ab3f0d6f66b8fc7fca3959ab5991f82221789be9"
+  integrity sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==
+
+socket.io-client@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.3.0.tgz#14d5ba2e00b9bcd145ae443ab96b3f86cbcc1bb4"
+  integrity sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==
+  dependencies:
+    backo2 "1.0.2"
+    base64-arraybuffer "0.1.5"
+    component-bind "1.0.0"
+    component-emitter "1.2.1"
+    debug "~4.1.0"
+    engine.io-client "~3.4.0"
+    has-binary2 "~1.0.2"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    object-component "0.0.3"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    socket.io-parser "~3.3.0"
+    to-array "0.1.4"
+
+socket.io-parser@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.0.tgz#2b52a96a509fdf31440ba40fed6094c7d4f1262f"
+  integrity sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==
+  dependencies:
+    component-emitter "1.2.1"
+    debug "~3.1.0"
+    isarray "2.0.1"
+
+socket.io-parser@~3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.4.1.tgz#b06af838302975837eab2dc980037da24054d64a"
+  integrity sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==
+  dependencies:
+    component-emitter "1.2.1"
+    debug "~4.1.0"
+    isarray "2.0.1"
+
+socket.io@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.3.0.tgz#cd762ed6a4faeca59bc1f3e243c0969311eb73fb"
+  integrity sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==
+  dependencies:
+    debug "~4.1.0"
+    engine.io "~3.4.0"
+    has-binary2 "~1.0.2"
+    socket.io-adapter "~1.1.0"
+    socket.io-client "2.3.0"
+    socket.io-parser "~3.4.0"
+
 sockjs-client@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.4.0.tgz#c9f2568e19c8fd8173b4997ea3420e0bb306c7d5"
@@ -10449,6 +10700,39 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+storyboard-core@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/storyboard-core/-/storyboard-core-3.2.0.tgz#6765e2c71bdc5b8ed1db52faf896df43461bca7c"
+  integrity sha512-v2p3SDYi22go1oLrJPnsiwXgSsjqKL6oryy9B3rz2UEpLwqWArjUoaECciD+/sfwJFJs1etIjUbE4tBx2G+adQ==
+  dependencies:
+    chalk "1.x"
+    lodash "^4.17.10"
+    platform "1.3.3"
+    semver "^5.3.0"
+    timm "^1.6.1"
+    uuid "^3.0.1"
+
+storyboard-listener-console@^3.1.1:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/storyboard-listener-console/-/storyboard-listener-console-3.1.4.tgz#165c23629721a0327b181d4b926bc2d9787eb661"
+  integrity sha512-zP2x0XKXHXGYrz4/RS4kxMp/4JqEvREV3rdkfbb6uqGld9gPKNqAdRDLQPN7cJRycTipTt+qew7RFGDTIVSIVA==
+  dependencies:
+    timm "^1.6.1"
+
+storyboard-preset-console@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/storyboard-preset-console/-/storyboard-preset-console-3.1.4.tgz#07c8c2aa7218739505663684ffb4f4b1b2a5f35f"
+  integrity sha512-w2JxIj5V6fLLlAeU3/EcsOcL2PdgnRbPrT0iwlqxPJxU7ROaVPfE4uJblfmgGSfDEuYd666gb0MDMOxw8OPSZQ==
+  dependencies:
+    storyboard-listener-console "^3.1.1"
+
+storyboard@^3.1.4:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/storyboard/-/storyboard-3.2.1.tgz#6a86d60d6693cffa74e341e6aca6319a980c896b"
+  integrity sha512-p3jUJbVXPooAijw4EF4nSEMAziC2N0sEbGcGKdoS2tgb39Y13TSk2y7OLSAOirikPvvcMRlSpKNVYDKMumwkKw==
+  dependencies:
+    storyboard-core "^3.2.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -10839,6 +11123,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+timm@^1.6.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/timm/-/timm-1.6.2.tgz#dfd8c6719f7ba1fcfc6295a32670a1c6d166c0bd"
+  integrity sha512-IH3DYDL1wMUwmIlVmMrmesw5lZD6N+ZOAFWEyLrtpoL9Bcrs9u7M/vyOnHzDD2SMs4irLkVjqxZbHrXStS/Nmw==
+
 timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
@@ -10860,6 +11149,11 @@ tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
   integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+
+to-array@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+  integrity sha1-F+bBH3PdTz10zaek/zI46a2b+JA=
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -11405,6 +11699,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
+
 whatwg-fetch@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.1.1.tgz#03f6b16271619003a5d42c1f14026523787a931e"
@@ -11665,6 +11964,18 @@ ws@^6.1.2, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^7.1.2:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
+  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+
+ws@~6.1.0:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz#5b5c8800afab925e94ccb29d153c8d02c1776ef9"
+  integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
+  dependencies:
+    async-limiter "~1.0.0"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -11674,6 +11985,11 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmlhttprequest-ssl@~1.5.4:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
+  integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
 xregexp@^4.3.0:
   version "4.3.0"
@@ -11761,3 +12077,8 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+  integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=


### PR DESCRIPTION
Files changed: 
- All snapshot files have been changed to add HTML preview reference for snapshot tests
- yarn.lock - Update existing dependencies and plugins and add dependencies for jest-html
- package.json - Add jest-html dependency and yarn script to add functionality to run in browser

Example of jest-html snapshot browser preview: https://screenshot.googleplex.com/Zz4iE9jdqTq